### PR TITLE
Remove make targets from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,6 @@ COPY controllers/ controllers/
 USER 0
 
 # Build
-RUN make test
-RUN make build-template
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary


### PR DESCRIPTION
* The main Dockerfile does not need to run make test or build-template.