### PR TITLE
[RHCLOUD-16957] Add SLO docs to operator

### DIFF
--- a/docs/slos/frontend-operator-availability.md
+++ b/docs/slos/frontend-operator-availability.md
@@ -1,0 +1,29 @@
+# Frontend Operator Availability SLO
+
+## Description
+
+The frontend operator availability SLO determines if the operator is functioning normally.
+This SLO tracks the deployment number of the frontend operator. There should always be at least
+1 deployment running for the operator.
+
+## SLI Rationale
+Availability is the most important metric we can gather for this operator. If there are no running
+pods, no operations can be conducted. Ensuring that we monitor the availability of the operator is
+critical to running ConsoleDot Frontends.
+
+## Implmentation
+
+The SLI for availability is enabled through kubernetes metrics. We can use the `kube_deployment_status_replicas_available`
+and filter on the `frontend-operator-system` namespace to determine if we have a running pod. Since
+the only thing running in that namespace is the controller operator, we can match our desired pod numbers to our alerts.
+
+## SLO Rationale
+
+The operator's uptime should be at least 99%. Availability is the basis of OpenShift deployments. We cannot reconcile
+Frontend resources without a running operator and it is a critical part of our deployment strategy for ConsoleDot.
+
+## Alerting
+
+Alerts for availability are high for now, but could become paged alerts in the future. When the operator becomes
+unavailable, it will not delete or remove any resources. Instead, no changes can be made to CRs on the cluster.
+While no destructive processes will be invoked, no changes can be made to frontend resources.

--- a/docs/slos/frontend-operator-reconciliation.md
+++ b/docs/slos/frontend-operator-reconciliation.md
@@ -1,0 +1,26 @@
+# Frontend Operator Reconciliation SLO
+
+## Description
+
+The frontend operator implements metrics to expose the error rate of reconcilations targeting its CRDs. When that
+error rate is too high, we will alert. Reconciliation errors can indicate a wide array of issue including misconfigurations,
+outages, and quota/resource constraints. In general, if the operator's cannot reconcile successfully at a nominal rate,
+investigation is needed.
+
+## SLI Rationale
+
+Reconciliation error rates show many different issues across several environments. We can use this metric to catch
+misconfigurations in production apps and find deploy time issues with the operator. 
+
+## Implmentation
+
+The Operator SDK exposes the `controller_runtime_reconcile_total` metric to show the nominal reconcilation rate. Using the
+`sum(increase)` modifier allows us to determine if that amount is less than 100%.
+
+## SLO Rationale
+Almost all reconciler calls should be handled without issue. If we are hitting more than 10% errors on reconcile, debugging
+should begin.
+
+## Alerting
+Alerts should be kept to a medium level. Because there are a myriad of issues that could cause a reconciliation error, breaking
+this SLO should not result in a page. It should be addressed, but error rate alone does not indiciate an outage.


### PR DESCRIPTION
In order to get sre onboarded, the operator needs to have some detailed SLO docs included. Adding two main SLO docs to start with, but more will be added here in the future. 