### PR TITLE
Add operator-name label to deployment

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -12,6 +12,7 @@ metadata:
   namespace: system
   labels:
     control-plane: controller-manager
+    operator-name: frontend-operator
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Needs to match the label `operator-name: frontend-operator` for the ServiceMonitor