### PR TITLE
Add route prefix to spec and inject that as ENV VAR to deployment

### DIFF
--- a/api/v1alpha1/frontend_types.go
+++ b/api/v1alpha1/frontend_types.go
@@ -51,6 +51,7 @@ type FrontendSpec struct {
 	Image          string               `json:"image,omitempty" yaml:"image,omitempty"`
 	Service        string               `json:"service,omitempty" yaml:"service,omitempty"`
 	ServiceMonitor ServiceMonitorConfig `json:"serviceMonitor,omitempty" yaml:"serviceMontior,omitempty"`
+	RoutePrefix    string               `json:"routePrefix,omitempty" yaml:"routePrefix,omitempty"`
 	Module         *FedModule           `json:"module,omitempty" yaml:"module,omitempty"`
 	NavItems       []*BundleNavItem     `json:"navItems,omitempty" yaml:"navItems,omitempty"`
 	AssetsPrefix   string               `json:"assetsPrefix,omitempty" yaml:"assetsPrefix,omitempty"`

--- a/config/crd/bases/cloud.redhat.com_frontends.yaml
+++ b/config/crd/bases/cloud.redhat.com_frontends.yaml
@@ -231,6 +231,8 @@ spec:
                   - title
                   type: object
                 type: array
+              routePrefix:
+                type: string
               service:
                 type: string
               serviceMonitor:

--- a/deploy.yml
+++ b/deploy.yml
@@ -628,6 +628,8 @@ objects:
                     - title
                     type: object
                   type: array
+                routePrefix:
+                  type: string
                 service:
                   type: string
                 serviceMonitor:

--- a/docs/antora/modules/ROOT/pages/api_reference.adoc
+++ b/docs/antora/modules/ROOT/pages/api_reference.adoc
@@ -373,6 +373,7 @@ FrontendSpec defines the desired state of Frontend
 | *`image`* __string__ | 
 | *`service`* __string__ | 
 | *`serviceMonitor`* __xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-servicemonitorconfig[$$ServiceMonitorConfig$$]__ | 
+| *`routePrefix`* __string__ | 
 | *`module`* __xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-fedmodule[$$FedModule$$]__ | 
 | *`navItems`* __xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-bundlenavitem[$$BundleNavItem$$] array__ | 
 | *`assetsPrefix`* __string__ | 


### PR DESCRIPTION
This patch adds a new RoutePrefix to the spec and injects that as an env var into the deployment