### PR TITLE
Add routePrefix to consoledot ingress paths

### DIFF
--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -300,8 +300,9 @@ func (r *FrontendReconciliation) createAnnotationsAndPopulate(nn types.Namespace
 
 func (r *FrontendReconciliation) getFrontendPaths() []string {
 	frontendPaths := r.Frontend.Spec.Frontend.Paths
-	defaultPath := fmt.Sprintf("/apps/%s", r.Frontend.Name)
-	defaultBetaPath := fmt.Sprintf("/beta/apps/%s", r.Frontend.Name)
+	routePrefix := r.routePrefix()
+	defaultPath := fmt.Sprintf("/%s/%s", routePrefix, r.Frontend.Name)
+	defaultBetaPath := fmt.Sprintf("/beta/%s/%s", routePrefix, r.Frontend.Name)
 	if r.Frontend.Spec.AssetsPrefix != "" {
 		defaultPath = fmt.Sprintf("/%s/%s", r.Frontend.Spec.AssetsPrefix, r.Frontend.Name)
 		defaultBetaPath = fmt.Sprintf("/beta/%s/%s", r.Frontend.Spec.AssetsPrefix, r.Frontend.Name)


### PR DESCRIPTION
This patch adds the routePrefix to the consoledot ingress (aka route) paths.