### PR TITLE
[RHCLOUD-23633] - Conditionally build Chrome config

### DIFF
--- a/api/v1alpha1/frontendenvironment_types.go
+++ b/api/v1alpha1/frontendenvironment_types.go
@@ -45,6 +45,11 @@ type FrontendEnvironmentSpec struct {
 	// local will add it to the frontend's namespace
 	// app-interface will add it to "openshift-customer-monitoring"
 	Monitoring *MonitoringConfig `json:"monitoring,omitempty"`
+
+	// GenerateChromeConfig determines if a chrome configmap will be generated
+	// If empty or false the chrome nav config in the chrome container will be used
+	// If true a configmap will be generated and mounted into the chrome container
+	GenerateChromeConfig bool `json:"generateChromeConfig,omitempty"`
 }
 
 type MonitoringConfig struct {

--- a/config/crd/bases/cloud.redhat.com_frontendenvironments.yaml
+++ b/config/crd/bases/cloud.redhat.com_frontendenvironments.yaml
@@ -45,6 +45,12 @@ spec:
           spec:
             description: FrontendEnvironmentSpec defines the desired state of FrontendEnvironment
             properties:
+              generateChromeConfig:
+                description: GenerateChromeConfig determines if a chrome configmap
+                  will be generated If empty or false the chrome nav config in the
+                  chrome container will be used If true a configmap will be generated
+                  and mounted into the chrome container
+                type: boolean
               hostname:
                 description: Hostname
                 type: string

--- a/controllers/frontend_controller_suite_test.go
+++ b/controllers/frontend_controller_suite_test.go
@@ -140,6 +140,7 @@ var _ = Describe("Frontend controller with image", func() {
 					Monitoring: &crd.MonitoringConfig{
 						Mode: "app-interface",
 					},
+					GenerateChromeConfig: true,
 				},
 			}
 			Expect(k8sClient.Create(ctx, frontendEnvironment)).Should(Succeed())
@@ -530,6 +531,7 @@ var _ = Describe("Frontend controller with chrome", func() {
 					Monitoring: &crd.MonitoringConfig{
 						Mode: "app-interface",
 					},
+					GenerateChromeConfig: true,
 				},
 			}
 			Expect(k8sClient.Create(ctx, frontendEnvironment)).Should(Succeed())
@@ -678,6 +680,7 @@ var _ = Describe("ServiceMonitor Creation", func() {
 					Monitoring: &crd.MonitoringConfig{
 						Mode: "app-interface",
 					},
+					GenerateChromeConfig: true,
 				},
 			}
 			Expect(k8sClient.Create(ctx, frontendEnvironment)).Should(Succeed())
@@ -881,6 +884,7 @@ var _ = Describe("Dependencies", func() {
 					Monitoring: &crd.MonitoringConfig{
 						Mode: "app-interface",
 					},
+					GenerateChromeConfig: true,
 				},
 			}
 			Expect(k8sClient.Create(ctx, frontendEnvironment)).Should(Succeed())

--- a/controllers/frontend_controller_suite_test.go
+++ b/controllers/frontend_controller_suite_test.go
@@ -256,6 +256,7 @@ var _ = Describe("Frontend controller with service", func() {
 					Monitoring: &crd.MonitoringConfig{
 						Mode: "local",
 					},
+					GenerateChromeConfig: true,
 				},
 			}
 			Expect(k8sClient.Create(ctx, &frontendEnvironment)).Should(Succeed())

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -192,24 +192,15 @@ func (r *FrontendReconciliation) createFrontendDeployment(annotationHashes []map
 
 	d.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
 
-	annotations := d.Spec.Template.GetAnnotations()
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
-
-	for _, hash := range annotationHashes {
-		for k, v := range hash {
-			annotations[k] = v
-		}
-	}
-
-	d.Spec.Template.SetAnnotations(annotations)
+	utils.UpdateAnnotations(&d.Spec.Template, annotationHashes...)
 
 	// This is a temporary measure to silence DVO from opening 600 million tickets for each frontend - Issue fix ETA is TBD
 	deploymentAnnotation := d.ObjectMeta.GetAnnotations()
 	if deploymentAnnotation == nil {
 		deploymentAnnotation = make(map[string]string)
 	}
+
+	// Gabor wrote the string "we don't need no any checking" and we will never change it
 	deploymentAnnotation["kube-linter.io/ignore-all"] = "we don't need no any checking"
 	d.ObjectMeta.SetAnnotations(deploymentAnnotation)
 

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -112,7 +112,10 @@ func populateContainer(d *apps.Deployment, frontend *crd.Frontend, frontendEnvir
 	}
 }
 
-func populateVolumes(d *apps.Deployment, frontend *crd.Frontend) {
+func populateVolumes(d *apps.Deployment, frontend *crd.Frontend, frontendEnvironment *crd.FrontendEnvironment) {
+	if !frontendEnvironment.Spec.GenerateChromeConfig {
+		return
+	}
 	d.Spec.Template.Spec.Volumes = []v1.Volume{
 		{
 			Name: "config",
@@ -162,7 +165,7 @@ func (r *FrontendReconciliation) createFrontendDeployment(hash, ssoHash string) 
 	labeler(d)
 
 	populateContainer(d, r.Frontend, r.FrontendEnvironment)
-	populateVolumes(d, r.Frontend)
+	populateVolumes(d, r.Frontend, r.FrontendEnvironment)
 
 	d.Spec.Template.ObjectMeta.Labels = labels
 

--- a/deploy.yml
+++ b/deploy.yml
@@ -346,6 +346,12 @@ objects:
             spec:
               description: FrontendEnvironmentSpec defines the desired state of FrontendEnvironment
               properties:
+                generateChromeConfig:
+                  description: GenerateChromeConfig determines if a chrome configmap
+                    will be generated If empty or false the chrome nav config in the
+                    chrome container will be used If true a configmap will be generated
+                    and mounted into the chrome container
+                  type: boolean
                 hostname:
                   description: Hostname
                   type: string

--- a/docs/antora/modules/ROOT/pages/api_reference.adoc
+++ b/docs/antora/modules/ROOT/pages/api_reference.adoc
@@ -311,6 +311,7 @@ FrontendEnvironmentSpec defines the desired state of FrontendEnvironment
 | *`hostname`* __string__ | Hostname
 | *`whitelist`* __string array__ | Whitelist CIDRs
 | *`monitoring`* __xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-monitoringconfig[$$MonitoringConfig$$]__ | MonitorMode determines where a ServiceMonitor object will be placed local will add it to the frontend's namespace app-interface will add it to "openshift-customer-monitoring"
+| *`generateChromeConfig`* __boolean__ | GenerateChromeConfig determines if a chrome configmap will be generated If empty or false the chrome nav config in the chrome container will be used If true a configmap will be generated and mounted into the chrome container
 |===
 
 

--- a/examples/chrome.yaml
+++ b/examples/chrome.yaml
@@ -14,4 +14,4 @@ spec:
     paths:
       - /
       - /config/chrome
-  image: quay.io/cloudservices/insights-chrome-frontend:1ddc0de
+  image: quay.io/cloudservices/insights-chrome-frontend:2712b0a

--- a/examples/feenvironment.yaml
+++ b/examples/feenvironment.yaml
@@ -7,3 +7,4 @@ spec:
   monitoring:
     mode: "local"
     disabled: false
+    generateChromeConfig: true


### PR DESCRIPTION
This patch makes generating the chrome config conditional on an addition to the FrontendEnvironment CRD spec. This will allow some environments, like stage and prod, to use a known-good stable config for chrome pulled from cloud-services-config and built into the chrome image, which environments like ephemeral can override that and use the bundle system for custom nav during development and testing.