### PR TITLE
Refactor config building, remove SSO cruft, change name in spec.

### DIFF
--- a/api/v1alpha1/frontendenvironment_types.go
+++ b/api/v1alpha1/frontendenvironment_types.go
@@ -50,10 +50,10 @@ type FrontendEnvironmentSpec struct {
 	// pod, the route is also set to reencrypt in the case of OpenShift
 	SSL bool `json:"ssl,omitempty"`
 
-	// GenerateChromeConfig determines if a chrome configmap will be generated
-	// If empty or false the chrome nav config in the chrome container will be used
-	// If true a configmap will be generated and mounted into the chrome container
-	GenerateChromeConfig bool `json:"generateChromeConfig,omitempty"`
+	// GenerateNavJSON determines if the nav json configmap
+	// parts should be generated for the bundles. We want to do
+	// do this in epehemeral environments but not in production
+	GenerateNavJSON bool `json:"generateNavJSON,omitempty"`
 }
 
 type MonitoringConfig struct {

--- a/config/crd/bases/cloud.redhat.com_frontendenvironments.yaml
+++ b/config/crd/bases/cloud.redhat.com_frontendenvironments.yaml
@@ -45,11 +45,10 @@ spec:
           spec:
             description: FrontendEnvironmentSpec defines the desired state of FrontendEnvironment
             properties:
-              generateChromeConfig:
-                description: GenerateChromeConfig determines if a chrome configmap
-                  will be generated If empty or false the chrome nav config in the
-                  chrome container will be used If true a configmap will be generated
-                  and mounted into the chrome container
+              generateNavJSON:
+                description: GenerateNavJSON determines if the nav json configmap
+                  parts should be generated for the bundles. We want to do do this
+                  in epehemeral environments but not in production
                 type: boolean
               hostname:
                 description: Hostname

--- a/controllers/frontend_controller_suite_test.go
+++ b/controllers/frontend_controller_suite_test.go
@@ -166,7 +166,6 @@ var _ = Describe("Frontend controller with image", func() {
 			deploymentLookupKey := types.NamespacedName{Name: frontend.Name + "-frontend", Namespace: FrontendNamespace}
 			ingressLookupKey := types.NamespacedName{Name: frontend.Name, Namespace: FrontendNamespace}
 			configMapLookupKey := types.NamespacedName{Name: frontendEnvironment.Name, Namespace: FrontendNamespace}
-			configSSOMapLookupKey := types.NamespacedName{Name: fmt.Sprintf("%s-sso", frontendEnvironment.Name), Namespace: FrontendNamespace}
 			serviceLookupKey := types.NamespacedName{Name: frontend.Name, Namespace: FrontendNamespace}
 			createdDeployment := &apps.Deployment{}
 
@@ -176,7 +175,6 @@ var _ = Describe("Frontend controller with image", func() {
 			}, timeout, interval).Should(BeTrue())
 			Expect(createdDeployment.Name).Should(Equal(FrontendName + "-frontend"))
 			fmt.Printf("\n%v\n", createdDeployment.GetAnnotations())
-			Expect(createdDeployment.Spec.Template.GetAnnotations()["ssoHash"]).ShouldNot(Equal(""))
 			Expect(createdDeployment.Spec.Template.GetAnnotations()["configHash"]).ShouldNot(Equal(""))
 
 			createdIngress := &networking.Ingress{}
@@ -210,11 +208,7 @@ var _ = Describe("Frontend controller with image", func() {
 				"test-env.json":    "{\"id\":\"test-bundle\",\"title\":\"\",\"navItems\":[{\"title\":\"Test\",\"href\":\"/test/href\"},{\"title\":\"Test\",\"href\":\"/test/href\"}]}",
 			}))
 			Expect(createdConfigMap.ObjectMeta.OwnerReferences[0].Name).Should(Equal(FrontendEnvName))
-			createdSSOConfigMap := &v1.ConfigMap{}
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, configSSOMapLookupKey, createdSSOConfigMap)
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+
 		})
 	})
 })
@@ -327,7 +321,6 @@ var _ = Describe("Frontend controller with service", func() {
 
 			ingressLookupKey := types.NamespacedName{Name: frontend.Name, Namespace: FrontendNamespace}
 			configMapLookupKey := types.NamespacedName{Name: frontendEnvironment.Name, Namespace: FrontendNamespace}
-			configSSOMapLookupKey := types.NamespacedName{Name: fmt.Sprintf("%s-sso", frontendEnvironment.Name), Namespace: FrontendNamespace}
 
 			createdIngress := &networking.Ingress{}
 			Eventually(func() bool {
@@ -349,12 +342,6 @@ var _ = Describe("Frontend controller with service", func() {
 				"fed-modules.json":      "{\"testFrontendService\":{\"manifestLocation\":\"/apps/inventory/fed-mods.json\",\"modules\":[{\"id\":\"test\",\"module\":\"./RootApp\",\"routes\":[{\"pathname\":\"/test/href\"}]}]}}",
 				"test-env-service.json": "{\"id\":\"test-service-bundle\",\"title\":\"\",\"navItems\":[{\"title\":\"Test\",\"href\":\"/test/href\"},{\"title\":\"Test2\",\"href\":\"/test/href2\"}]}",
 			}))
-
-			createdSSOConfigMap := &v1.ConfigMap{}
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, configSSOMapLookupKey, createdSSOConfigMap)
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
 
 			Eventually(func() bool {
 				nfe := &crd.Frontend{}
@@ -558,7 +545,6 @@ var _ = Describe("Frontend controller with chrome", func() {
 			deploymentLookupKey := types.NamespacedName{Name: frontend.Name + "-frontend", Namespace: FrontendNamespace}
 			ingressLookupKey := types.NamespacedName{Name: frontend.Name, Namespace: FrontendNamespace}
 			configMapLookupKey := types.NamespacedName{Name: frontendEnvironment.Name, Namespace: FrontendNamespace}
-			configSSOMapLookupKey := types.NamespacedName{Name: fmt.Sprintf("%s-sso", frontendEnvironment.Name), Namespace: FrontendNamespace}
 			serviceLookupKey := types.NamespacedName{Name: frontend.Name, Namespace: FrontendNamespace}
 			createdDeployment := &apps.Deployment{}
 
@@ -568,7 +554,6 @@ var _ = Describe("Frontend controller with chrome", func() {
 			}, timeout, interval).Should(BeTrue())
 			Expect(createdDeployment.Name).Should(Equal(FrontendName + "-frontend"))
 			fmt.Printf("\n%v\n", createdDeployment.GetAnnotations())
-			Expect(createdDeployment.Spec.Template.GetAnnotations()["ssoHash"]).ShouldNot(Equal(""))
 			Expect(createdDeployment.Spec.Template.GetAnnotations()["configHash"]).ShouldNot(Equal(""))
 
 			createdIngress := &networking.Ingress{}
@@ -601,11 +586,7 @@ var _ = Describe("Frontend controller with chrome", func() {
 				"fed-modules.json":     "{\"chrome\":{\"manifestLocation\":\"/apps/inventory/fed-mods.json\",\"modules\":[{\"id\":\"test\",\"module\":\"./RootApp\",\"routes\":[{\"pathname\":\"/test/href\"}]}],\"config\":{\"apple\":\"pie\",\"ssoUrl\":\"https://something-auth\"}},\"noConfig\":{\"manifestLocation\":\"/apps/inventory/fed-mods.json\",\"modules\":[{\"id\":\"test\",\"module\":\"./RootApp\",\"routes\":[{\"pathname\":\"/test/href\"}]}]},\"nonChrome\":{\"manifestLocation\":\"/apps/inventory/fed-mods.json\",\"modules\":[{\"id\":\"test\",\"module\":\"./RootApp\",\"routes\":[{\"pathname\":\"/test/href\"}]}],\"config\":{\"apple\":\"pie\"}}}",
 				"test-chrome-env.json": "{\"id\":\"test-chrome-bundle\",\"title\":\"\",\"navItems\":[{\"title\":\"Test\",\"href\":\"/test/href\"},{\"title\":\"Test\",\"href\":\"/test/href\"},{\"title\":\"Test\",\"href\":\"/test/href\"}]}"}))
 			Expect(createdConfigMap.ObjectMeta.OwnerReferences[0].Name).Should(Equal(FrontendEnvName))
-			createdSSOConfigMap := &v1.ConfigMap{}
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, configSSOMapLookupKey, createdSSOConfigMap)
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+
 		})
 	})
 })

--- a/controllers/frontend_controller_suite_test.go
+++ b/controllers/frontend_controller_suite_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Frontend controller with image", func() {
 					Monitoring: &crd.MonitoringConfig{
 						Mode: "app-interface",
 					},
-					GenerateChromeConfig: true,
+					GenerateNavJSON: true,
 				},
 			}
 			Expect(k8sClient.Create(ctx, frontendEnvironment)).Should(Succeed())
@@ -256,7 +256,7 @@ var _ = Describe("Frontend controller with service", func() {
 					Monitoring: &crd.MonitoringConfig{
 						Mode: "local",
 					},
-					GenerateChromeConfig: true,
+					GenerateNavJSON: true,
 				},
 			}
 			Expect(k8sClient.Create(ctx, &frontendEnvironment)).Should(Succeed())
@@ -532,7 +532,7 @@ var _ = Describe("Frontend controller with chrome", func() {
 					Monitoring: &crd.MonitoringConfig{
 						Mode: "app-interface",
 					},
-					GenerateChromeConfig: true,
+					GenerateNavJSON: true,
 				},
 			}
 			Expect(k8sClient.Create(ctx, frontendEnvironment)).Should(Succeed())
@@ -681,7 +681,7 @@ var _ = Describe("ServiceMonitor Creation", func() {
 					Monitoring: &crd.MonitoringConfig{
 						Mode: "app-interface",
 					},
-					GenerateChromeConfig: true,
+					GenerateNavJSON: true,
 				},
 			}
 			Expect(k8sClient.Create(ctx, frontendEnvironment)).Should(Succeed())
@@ -885,7 +885,7 @@ var _ = Describe("Dependencies", func() {
 					Monitoring: &crd.MonitoringConfig{
 						Mode: "app-interface",
 					},
-					GenerateChromeConfig: true,
+					GenerateNavJSON: true,
 				},
 			}
 			Expect(k8sClient.Create(ctx, frontendEnvironment)).Should(Succeed())

--- a/deploy.yml
+++ b/deploy.yml
@@ -346,11 +346,10 @@ objects:
             spec:
               description: FrontendEnvironmentSpec defines the desired state of FrontendEnvironment
               properties:
-                generateChromeConfig:
-                  description: GenerateChromeConfig determines if a chrome configmap
-                    will be generated If empty or false the chrome nav config in the
-                    chrome container will be used If true a configmap will be generated
-                    and mounted into the chrome container
+                generateNavJSON:
+                  description: GenerateNavJSON determines if the nav json configmap
+                    parts should be generated for the bundles. We want to do do this
+                    in epehemeral environments but not in production
                   type: boolean
                 hostname:
                   description: Hostname

--- a/docs/antora/modules/ROOT/pages/api_reference.adoc
+++ b/docs/antora/modules/ROOT/pages/api_reference.adoc
@@ -312,7 +312,7 @@ FrontendEnvironmentSpec defines the desired state of FrontendEnvironment
 | *`whitelist`* __string array__ | Whitelist CIDRs
 | *`monitoring`* __xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-monitoringconfig[$$MonitoringConfig$$]__ | MonitorMode determines where a ServiceMonitor object will be placed local will add it to the frontend's namespace app-interface will add it to "openshift-customer-monitoring"
 | *`ssl`* __boolean__ | SSL mode requests SSL from the services in openshift and k8s and then applies them to the pod, the route is also set to reencrypt in the case of OpenShift
-| *`generateChromeConfig`* __boolean__ | GenerateChromeConfig determines if a chrome configmap will be generated If empty or false the chrome nav config in the chrome container will be used If true a configmap will be generated and mounted into the chrome container
+| *`generateNavJSON`* __boolean__ | GenerateNavJSON determines if the nav json configmap parts should be generated for the bundles. We want to do do this in epehemeral environments but not in production
 |===
 
 


### PR DESCRIPTION
This patch removes the old SSO generation code, changes the conditionality on the config json building to only wrap nav generation and restores fed-modules generation for all environments. Change spec name to mantain accuracy. Fix comments.