### PR TITLE
Create env vars if SSL mode is on

### DIFF
--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -193,7 +193,7 @@ func (r *FrontendReconciliation) populateEnvVars(d *apps.Deployment, frontendEnv
 		},
 		{
 			Name:  "CADDY_TLS_CERT",
-			Value: "tlc /opt/certs/tls.cert /opt/certs/tls.key",
+			Value: "tls /opt/certs/tls.cert /opt/certs/tls.key",
 		}}
 	d.Spec.Template.Spec.Containers[0].Env = envVars
 }

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -187,16 +187,14 @@ func (r *FrontendReconciliation) populateEnvVars(d *apps.Deployment, frontendEnv
 		return
 	}
 	envVars := []v1.EnvVar{}
-	if frontendEnvironment.Spec.SSL {
-		envVars = append(envVars, v1.EnvVar{
-			Name:  "CADDY_TLS_MODE",
-			Value: "https_port 8000",
-		})
-		envVars = append(envVars, v1.EnvVar{
-			Name:  "CADDY_TLS_CERT",
-			Value: "tlc /opt/certs/tls.cert /opt/certs/tls.key",
-		})
-	}
+	envVars = append(envVars, v1.EnvVar{
+		Name:  "CADDY_TLS_MODE",
+		Value: "https_port 8000",
+	})
+	envVars = append(envVars, v1.EnvVar{
+		Name:  "CADDY_TLS_CERT",
+		Value: "tlc /opt/certs/tls.cert /opt/certs/tls.key",
+	})
 	d.Spec.Template.Spec.Containers[0].Env = envVars
 }
 

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -186,15 +186,15 @@ func (r *FrontendReconciliation) populateEnvVars(d *apps.Deployment, frontendEnv
 	if !frontendEnvironment.Spec.SSL {
 		return
 	}
-	envVars := []v1.EnvVar{}
-	envVars = append(envVars, v1.EnvVar{
-		Name:  "CADDY_TLS_MODE",
-		Value: "https_port 8000",
-	})
-	envVars = append(envVars, v1.EnvVar{
-		Name:  "CADDY_TLS_CERT",
-		Value: "tlc /opt/certs/tls.cert /opt/certs/tls.key",
-	})
+	envVars := []v1.EnvVar{
+		{
+			Name:  "CADDY_TLS_MODE",
+			Value: "https_port 8000",
+		},
+		{
+			Name:  "CADDY_TLS_CERT",
+			Value: "tlc /opt/certs/tls.cert /opt/certs/tls.key",
+		}}
 	d.Spec.Template.Spec.Containers[0].Env = envVars
 }
 

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -180,9 +180,8 @@ func populateVolumes(d *apps.Deployment, frontend *crd.Frontend, frontendEnviron
 	d.Spec.Template.Spec.Volumes = volumes
 }
 
+// Add the SSL env vars if we SSL mode is set in the frontend environment
 func (r *FrontendReconciliation) populateEnvVars(d *apps.Deployment, frontendEnvironment *crd.FrontendEnvironment) {
-	// If we are generating SSL then we need to add the environment variables
-	// for the cert and key
 	if !frontendEnvironment.Spec.SSL {
 		return
 	}


### PR DESCRIPTION
This patch adds the env vars that caddy cares about in SSL mode to the container 