### PR TITLE
[RHCLOUD-25110] Remove generating fed-modules.json in non generateNavJSON environments

### DIFF
--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -87,14 +87,6 @@ func populateContainerVolumeMounts(frontendEnvironment *crd.FrontendEnvironment)
 			Name:      "config",
 			MountPath: "/opt/app-root/src/build/chrome",
 		})
-	} else {
-		// If we are not generating the nav JSON then we need to mount the fed-modules.json
-		// and leave the rest of the directory intact
-		volumeMounts = append(volumeMounts, v1.VolumeMount{
-			Name:      "config",
-			MountPath: "/opt/app-root/src/build/chrome/fed-modules.json",
-			SubPath:   "fed-modules.json",
-		})
 	}
 
 	// We generate SSL cert mounts conditionally


### PR DESCRIPTION
We don't need to generate fed-modules.json unless generateNavJSON is true. This will prevent us from stomping over fed-modules.json in chrome config in prod and stage