### PR TITLE
[RHCLOUD-25113] Always mount generated config outside of the root chrome config

### DIFF
--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -89,6 +89,14 @@ func populateContainerVolumeMounts(frontendEnvironment *crd.FrontendEnvironment)
 		})
 	}
 
+	//We always want to mount the config map under the generated-config directory
+	//This will allow chrome to incorperate the generated nav and fed-modules.json
+	//at run time. This means chrome can merge the config in mixed environments
+	volumeMounts = append(volumeMounts, v1.VolumeMount{
+		Name:      "config",
+		MountPath: "/opt/app-root/src/build/generated-config",
+	})
+
 	// We generate SSL cert mounts conditionally
 	if frontendEnvironment.Spec.SSL {
 		volumeMounts = append(volumeMounts, v1.VolumeMount{
@@ -134,23 +142,6 @@ func populateVolumes(d *apps.Deployment, frontend *crd.Frontend, frontendEnviron
 				ConfigMap: &v1.ConfigMapVolumeSource{
 					LocalObjectReference: v1.LocalObjectReference{
 						Name: frontend.Spec.EnvName,
-					},
-				},
-			},
-		})
-	} else {
-		volumes = append(volumes, v1.Volume{
-			Name: "config",
-			VolumeSource: v1.VolumeSource{
-				ConfigMap: &v1.ConfigMapVolumeSource{
-					LocalObjectReference: v1.LocalObjectReference{
-						Name: frontend.Spec.EnvName,
-					},
-					Items: []v1.KeyToPath{
-						{
-							Key:  "fed-modules.json",
-							Path: "fed-modules.json",
-						},
 					},
 				},
 			},

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -89,9 +89,9 @@ func populateContainerVolumeMounts(frontendEnvironment *crd.FrontendEnvironment)
 		})
 	}
 
-	//We always want to mount the config map under the operator-generated directory
-	//This will allow chrome to incorperate the generated nav and fed-modules.json
-	//at run time. This means chrome can merge the config in mixed environments
+	// We always want to mount the config map under the operator-generated directory
+	// This will allow chrome to incorperate the generated nav and fed-modules.json
+	// at run time. This means chrome can merge the config in mixed environments
 	volumeMounts = append(volumeMounts, v1.VolumeMount{
 		Name:      "config",
 		MountPath: "/opt/app-root/src/build/operator-generated",

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -89,12 +89,12 @@ func populateContainerVolumeMounts(frontendEnvironment *crd.FrontendEnvironment)
 		})
 	}
 
-	//We always want to mount the config map under the generated-config directory
+	//We always want to mount the config map under the operator-generated directory
 	//This will allow chrome to incorperate the generated nav and fed-modules.json
 	//at run time. This means chrome can merge the config in mixed environments
 	volumeMounts = append(volumeMounts, v1.VolumeMount{
 		Name:      "config",
-		MountPath: "/opt/app-root/src/build/generated-config",
+		MountPath: "/opt/app-root/src/build/operator-generated",
 	})
 
 	// We generate SSL cert mounts conditionally


### PR DESCRIPTION
This patch adds a new feature where the generated config is mounted in a new location /opt/app-root/src/build/generated-config, even if we have nav generation off. This will mean that the normal /config/chrome will be either the pulls from cloud-serivices-config or what is generated by the operator depending on the env config, but we will have a new /config/operator-generated that will contain what the operator generated. Chrome can merge this with what's in /config/chrome to pull in generated config in a mixed environment