### PR TITLE
Fix edgerc mount

### DIFF
--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -265,7 +265,7 @@ func (r *FrontendReconciliation) populateInitContainer(d *apps.Deployment, front
 		VolumeMounts: []v1.VolumeMount{
 			{
 				Name:      "akamai-edgerc",
-				MountPath: "/opt/app-root/",
+				MountPath: "/opt/app-root/edgerc",
 				SubPath:   "edgerc",
 			},
 		},

--- a/tests/e2e/cachebust/02-assert.yaml
+++ b/tests/e2e/cachebust/02-assert.yaml
@@ -40,7 +40,7 @@ spec:
           resources: {}
           volumeMounts:
             - name: akamai-edgerc
-              mountPath: /opt/app-root/
+              mountPath: /opt/app-root/edgerc
               subPath: edgerc
       containers:
         - name: fe-image
@@ -101,7 +101,7 @@ spec:
           resources: {}
           volumeMounts:
             - name: akamai-edgerc
-              mountPath: /opt/app-root/
+              mountPath: /opt/app-root/edgerc
               subPath: edgerc
       containers:
         - name: fe-image


### PR DESCRIPTION
I had the subpath for the edgerc mount wrong. Didn't fail in tests because I fit the test to the output when I initially built it out - I noticed it when I tried to use the real cache bust image. Updated the code and the test.