### PR TITLE
Make cache bust a container instead of an init container

### DIFF
--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -255,7 +255,7 @@ func (r *FrontendReconciliation) populateCacheBustContainer(d *apps.Deployment, 
 	pathsToCacheBust := createCachePurgePathList(frontend, frontendEnvironment)
 
 	// Construct the akamai cache bust command
-	command := fmt.Sprintf("sleep 60; /cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc invalidate %s", strings.Join(pathsToCacheBust, " "))
+	command := fmt.Sprintf("sleep 60; /cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc delete %s", strings.Join(pathsToCacheBust, " "))
 
 	// Modify the obejct to set the things we care about
 	cacheBustContainer := v1.Container{

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -198,8 +198,8 @@ func createCachePurgePathList(frontend *crd.Frontend, frontendEnvironment *crd.F
 	return purgePaths
 }
 
-// populateInitContainer adds the akamai cache bust init container to the deployment
-func (r *FrontendReconciliation) populateInitContainer(d *apps.Deployment, frontend *crd.Frontend, frontendEnvironment *crd.FrontendEnvironment) error {
+// populateCacheBustContainer adds the akamai cache bust container to the deployment
+func (r *FrontendReconciliation) populateCacheBustContainer(d *apps.Deployment, frontend *crd.Frontend, frontendEnvironment *crd.FrontendEnvironment) error {
 	// Guard on frontend opting out of cache busting
 	if frontend.Spec.AkamaiCacheBustDisable {
 		return nil
@@ -255,10 +255,10 @@ func (r *FrontendReconciliation) populateInitContainer(d *apps.Deployment, front
 	pathsToCacheBust := createCachePurgePathList(frontend, frontendEnvironment)
 
 	// Construct the akamai cache bust command
-	command := fmt.Sprintf("/cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc invalidate %s", strings.Join(pathsToCacheBust, " "))
+	command := fmt.Sprintf("sleep 60; /cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc invalidate %s", strings.Join(pathsToCacheBust, " "))
 
 	// Modify the obejct to set the things we care about
-	d.Spec.Template.Spec.InitContainers = []v1.Container{{
+	cacheBustContainer := v1.Container{
 		Name:  "akamai-cache-bust",
 		Image: frontendEnvironment.Spec.AkamaiCacheBustImage,
 		// Mount the akamai edgerc file from the configmap
@@ -271,8 +271,10 @@ func (r *FrontendReconciliation) populateInitContainer(d *apps.Deployment, front
 		},
 		// Run the akamai cache bust script
 		Command: []string{"/bin/bash", "-c", command},
-	},
 	}
+	// add the container to the spec containers
+	d.Spec.Template.Spec.Containers = append(d.Spec.Template.Spec.Containers, cacheBustContainer)
+
 	// Add the akamai edgerc configmap to the deployment
 
 	return nil
@@ -352,9 +354,9 @@ func (r *FrontendReconciliation) createFrontendDeployment(annotationHashes []map
 	populateContainer(d, r.Frontend, r.FrontendEnvironment)
 	r.populateEnvVars(d, r.FrontendEnvironment)
 
-	// If cache busting is enabled for the environment, add the akamai cache bust init container
+	// If cache busting is enabled for the environment, add the akamai cache bust container
 	if r.FrontendEnvironment.Spec.EnableAkamaiCacheBust && r.FrontendEnvironment.Spec.AkamaiCacheBustImage != "" {
-		if err := r.populateInitContainer(d, r.Frontend, r.FrontendEnvironment); err != nil {
+		if err := r.populateCacheBustContainer(d, r.Frontend, r.FrontendEnvironment); err != nil {
 			return err
 		}
 	}

--- a/tests/e2e/cachebust/02-assert.yaml
+++ b/tests/e2e/cachebust/02-assert.yaml
@@ -27,21 +27,6 @@ spec:
           configMap:
             name: akamai-edgerc
             defaultMode: 420
-      initContainers:
-        - name: akamai-cache-bust
-          image: quay.io/rh_ee_addrew/hi_true_bye:add_alias
-          command:
-            - /bin/bash
-            - '-c'
-            - >-
-              /cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc
-              invalidate https://console.doesntexist.redhat.com/config/chrome/fed-modules.json
-              https://console.doesntexist.redhat.com/apps/chrome/index.html
-          resources: {}
-          volumeMounts:
-            - name: akamai-edgerc
-              mountPath: /opt/app-root/edgerc
-              subPath: edgerc
       containers:
         - name: fe-image
           image: quay.io/cloudservices/insights-chrome-frontend:720317c
@@ -59,6 +44,20 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent
+        - name: akamai-cache-bust
+          image: quay.io/rh_ee_addrew/hi_true_bye:add_alias
+          command:
+            - /bin/bash
+            - '-c'
+            - >-
+              sleep 60; /cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc
+              invalidate https://console.doesntexist.redhat.com/config/chrome/fed-modules.json
+              https://console.doesntexist.redhat.com/apps/chrome/index.html
+          resources: {}
+          volumeMounts:
+            - name: akamai-edgerc
+              mountPath: /opt/app-root/edgerc
+              subPath: edgerc
 ---
 kind: Deployment
 apiVersion: apps/v1
@@ -89,20 +88,6 @@ spec:
           configMap:
             name: akamai-edgerc
             defaultMode: 420
-      initContainers:
-        - name: akamai-cache-bust
-          image: quay.io/rh_ee_addrew/hi_true_bye:add_alias
-          command:
-            - /bin/bash
-            - '-c'
-            - >-
-              /cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc
-              invalidate https://console.doesntexist.redhat.com/apps/chrome-test-defaults/fed-mods.json
-          resources: {}
-          volumeMounts:
-            - name: akamai-edgerc
-              mountPath: /opt/app-root/edgerc
-              subPath: edgerc
       containers:
         - name: fe-image
           image: quay.io/cloudservices/insights-chrome-frontend:720317c
@@ -120,6 +105,19 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent
+        - name: akamai-cache-bust
+          image: quay.io/rh_ee_addrew/hi_true_bye:add_alias
+          command:
+            - /bin/bash
+            - '-c'
+            - >-
+              sleep 60; /cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc
+              invalidate https://console.doesntexist.redhat.com/apps/chrome-test-defaults/fed-mods.json
+          resources: {}
+          volumeMounts:
+            - name: akamai-edgerc
+              mountPath: /opt/app-root/edgerc
+              subPath: edgerc
 ---
 kind: Deployment
 apiVersion: apps/v1


### PR DESCRIPTION
This refactor eliminates the delay between cache bust and app app availability by making the cache bust happen in a container in the pod rather than an init container, and adds a delay to the cache bust. this way the frontend will be up and available before the cache bust occurs.