### PR TITLE
Move from container to job for cache bust

### DIFF
--- a/controllers/frontend_controller.go
+++ b/controllers/frontend_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	apps "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -68,6 +69,7 @@ func createNewScheme() *runtime.Scheme {
 var scheme = createNewScheme()
 
 var CoreDeployment = resCache.NewSingleResourceIdent("main", "deployment", &apps.Deployment{})
+var CoreJob = resCache.NewSingleResourceIdent("main", "job", &batchv1.Job{})
 var CoreService = resCache.NewSingleResourceIdent("main", "service", &v1.Service{})
 var CoreConfig = resCache.NewSingleResourceIdent("main", "config", &v1.ConfigMap{})
 var SSOConfig = resCache.NewSingleResourceIdent("main", "sso_config", &v1.ConfigMap{})

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -430,11 +430,12 @@ func (r *FrontendReconciliation) createCacheBustJob() error {
 
 	j.Spec.Completions = utils.Int32Ptr(1)
 
-	r.populateCacheBustContainer(j)
+	err := r.populateCacheBustContainer(j)
+	if err != nil {
+		return err
+	}
 
-	// Inform the cache that our updates are complete
-	err := r.Cache.Update(CoreJob, j)
-	return err
+	return r.Cache.Update(CoreJob, j)
 }
 
 // Will need to create a service resource ident in provider like CoreDeployment

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
 
+	batchv1 "k8s.io/api/batch/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -64,6 +65,12 @@ func (r *FrontendReconciliation) run() error {
 		}
 		if err := r.createFrontendService(); err != nil {
 			return err
+		}
+		// If cache busting is enabled for the environment, add the akamai cache bust container
+		if r.FrontendEnvironment.Spec.EnableAkamaiCacheBust && r.FrontendEnvironment.Spec.AkamaiCacheBustImage != "" {
+			if err := r.createCacheBustJob(); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -199,15 +206,11 @@ func createCachePurgePathList(frontend *crd.Frontend, frontendEnvironment *crd.F
 }
 
 // populateCacheBustContainer adds the akamai cache bust container to the deployment
-func (r *FrontendReconciliation) populateCacheBustContainer(d *apps.Deployment, frontend *crd.Frontend, frontendEnvironment *crd.FrontendEnvironment) error {
-	// Guard on frontend opting out of cache busting
-	if frontend.Spec.AkamaiCacheBustDisable {
-		return nil
-	}
+func (r *FrontendReconciliation) populateCacheBustContainer(j *batchv1.Job) error {
 
 	// Get the akamai secret
-	akamaiSecretName := getAkamaiSecretName(frontendEnvironment)
-	secret, err := getAkamaiSecret(r.Ctx, r.Client, frontend, akamaiSecretName)
+	akamaiSecretName := getAkamaiSecretName(r.FrontendEnvironment)
+	secret, err := getAkamaiSecret(r.Ctx, r.Client, r.Frontend, akamaiSecretName)
 	if err != nil {
 		return err
 	}
@@ -249,18 +252,18 @@ func (r *FrontendReconciliation) populateCacheBustContainer(d *apps.Deployment, 
 		},
 	}
 
-	d.Spec.Template.Spec.Volumes = append(d.Spec.Template.Spec.Volumes, akamaiVolume)
+	j.Spec.Template.Spec.Volumes = append(j.Spec.Template.Spec.Volumes, akamaiVolume)
 
 	// Get the paths to cache bust
-	pathsToCacheBust := createCachePurgePathList(frontend, frontendEnvironment)
+	pathsToCacheBust := createCachePurgePathList(r.Frontend, r.FrontendEnvironment)
 
 	// Construct the akamai cache bust command
-	command := fmt.Sprintf("sleep 60; /cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc delete %s ; while :; do sleep 1d; done", strings.Join(pathsToCacheBust, " "))
+	command := fmt.Sprintf("sleep 60; /cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc delete %s ", strings.Join(pathsToCacheBust, " "))
 
 	// Modify the obejct to set the things we care about
 	cacheBustContainer := v1.Container{
 		Name:  "akamai-cache-bust",
-		Image: frontendEnvironment.Spec.AkamaiCacheBustImage,
+		Image: r.FrontendEnvironment.Spec.AkamaiCacheBustImage,
 		// Mount the akamai edgerc file from the configmap
 		VolumeMounts: []v1.VolumeMount{
 			{
@@ -273,7 +276,7 @@ func (r *FrontendReconciliation) populateCacheBustContainer(d *apps.Deployment, 
 		Command: []string{"/bin/bash", "-c", command},
 	}
 	// add the container to the spec containers
-	d.Spec.Template.Spec.Containers = append(d.Spec.Template.Spec.Containers, cacheBustContainer)
+	j.Spec.Template.Spec.Containers = append(j.Spec.Template.Spec.Containers, cacheBustContainer)
 
 	// Add the akamai edgerc configmap to the deployment
 
@@ -354,13 +357,6 @@ func (r *FrontendReconciliation) createFrontendDeployment(annotationHashes []map
 	populateContainer(d, r.Frontend, r.FrontendEnvironment)
 	r.populateEnvVars(d, r.FrontendEnvironment)
 
-	// If cache busting is enabled for the environment, add the akamai cache bust container
-	if r.FrontendEnvironment.Spec.EnableAkamaiCacheBust && r.FrontendEnvironment.Spec.AkamaiCacheBustImage != "" {
-		if err := r.populateCacheBustContainer(d, r.Frontend, r.FrontendEnvironment); err != nil {
-			return err
-		}
-	}
-
 	d.Spec.Template.ObjectMeta.Labels = labels
 
 	d.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
@@ -400,6 +396,45 @@ func createPorts() []v1.ServicePort {
 			AppProtocol: &appProtocol,
 		},
 	}
+}
+
+func (r *FrontendReconciliation) createCacheBustJob() error {
+	// Guard on frontend opting out of cache busting
+	if r.Frontend.Spec.AkamaiCacheBustDisable {
+		return nil
+	}
+
+	// Create job
+	j := &batchv1.Job{}
+
+	jobName := r.Frontend.Name + "-frontend-cachebust"
+
+	// Define name of resource
+	nn := types.NamespacedName{
+		Name:      jobName,
+		Namespace: r.Frontend.Namespace,
+	}
+
+	// Create object in cache (will populate cache if exists)
+	if err := r.Cache.Create(CoreJob, nn, j); err != nil {
+		return err
+	}
+
+	// Label with the right labels
+	labels := r.Frontend.GetLabels()
+
+	labeler := utils.GetCustomLabeler(labels, nn, r.Frontend)
+	labeler(j)
+
+	j.Spec.Template.Spec.RestartPolicy = v1.RestartPolicyNever
+
+	j.Spec.Completions = utils.Int32Ptr(1)
+
+	r.populateCacheBustContainer(j)
+
+	// Inform the cache that our updates are complete
+	err := r.Cache.Update(CoreJob, j)
+	return err
 }
 
 // Will need to create a service resource ident in provider like CoreDeployment

--- a/tests/e2e/cachebust/02-assert.yaml
+++ b/tests/e2e/cachebust/02-assert.yaml
@@ -23,10 +23,6 @@ spec:
           configMap:
             name: test-cachebust-environment
             defaultMode: 420
-        - name: akamai-edgerc
-          configMap:
-            name: akamai-edgerc
-            defaultMode: 420
       containers:
         - name: fe-image
           image: quay.io/cloudservices/insights-chrome-frontend:720317c
@@ -44,21 +40,42 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chrome-test-filelist-frontend-cachebust
+  namespace: test-cachebust
+  labels:
+    frontend: chrome-test-filelist
+  ownerReferences:
+    - apiVersion: cloud.redhat.com/v1alpha1
+      kind: Frontend
+      name: chrome-test-filelist
+spec:
+  template:
+    spec:
+      volumes:
+        - name: akamai-edgerc
+          configMap:
+            name: akamai-edgerc
+            defaultMode: 420
+      containers:
         - name: akamai-cache-bust
           image: quay.io/rh_ee_addrew/hi_true_bye:add_alias
           command:
             - /bin/bash
             - '-c'
             - >-
-              sleep 60; /cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc
+              echo 'Starting' ; sleep 60; /cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc
               delete https://console.doesntexist.redhat.com/config/chrome/fed-modules.json
-              https://console.doesntexist.redhat.com/apps/chrome/index.html
-              ; while :; do sleep 1d; done
+              https://console.doesntexist.redhat.com/apps/chrome/index.html 
           resources: {}
           volumeMounts:
             - name: akamai-edgerc
               mountPath: /opt/app-root/edgerc
               subPath: edgerc
+      restartPolicy: Never
 ---
 kind: Deployment
 apiVersion: apps/v1
@@ -85,10 +102,6 @@ spec:
           configMap:
             name: test-cachebust-environment
             defaultMode: 420
-        - name: akamai-edgerc
-          configMap:
-            name: akamai-edgerc
-            defaultMode: 420
       containers:
         - name: fe-image
           image: quay.io/cloudservices/insights-chrome-frontend:720317c
@@ -106,6 +119,27 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chrome-test-defaults-frontend-cachebust
+  namespace: test-cachebust
+  labels:
+    frontend: chrome-test-defaults
+  ownerReferences:
+    - apiVersion: cloud.redhat.com/v1alpha1
+      kind: Frontend
+      name: chrome-test-defaults
+spec:
+  template:
+    spec:
+      volumes:
+        - name: akamai-edgerc
+          configMap:
+            name: akamai-edgerc
+            defaultMode: 420
+      containers:
         - name: akamai-cache-bust
           image: quay.io/rh_ee_addrew/hi_true_bye:add_alias
           command:
@@ -113,13 +147,13 @@ spec:
             - '-c'
             - >-
               sleep 60; /cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc
-              delete https://console.doesntexist.redhat.com/apps/chrome-test-defaults/fed-mods.json
-              ; while :; do sleep 1d; done
+              delete https://console.doesntexist.redhat.com/apps/chrome-test-defaults/fed-mods.json 
           resources: {}
           volumeMounts:
             - name: akamai-edgerc
               mountPath: /opt/app-root/edgerc
               subPath: edgerc
+      restartPolicy: Never
 ---
 kind: Deployment
 apiVersion: apps/v1


### PR DESCRIPTION
More drama on the road to cache busting. We started with initContainer and didn't like it because the cache busted too long before app starting. Then we moved to another container in the pod, but we didn't like that because a container has to be long running and has to just loop forever, which is wasteful and confusing - as well as exposing the entire deployment to risk of failure for a bogus reason. So, this refactors AGAIN on a job.