### PR TITLE
Add optional route props to route

### DIFF
--- a/api/v1alpha1/frontend_types.go
+++ b/api/v1alpha1/frontend_types.go
@@ -93,9 +93,10 @@ type Module struct {
 }
 
 type Route struct {
-	Pathname string `json:"pathname" yaml:"pathname"`
-	Dynamic  bool   `json:"dynamic,omitempty" yaml:"dynamic,omitempty"`
-	Exact    bool   `json:"exact,omitempty" yaml:"exact,omitempty"`
+	Pathname string              `json:"pathname" yaml:"pathname"`
+	Dynamic  bool                `json:"dynamic,omitempty" yaml:"dynamic,omitempty"`
+	Exact    bool                `json:"exact,omitempty" yaml:"exact,omitempty"`
+	Props    *apiextensions.JSON `json:"props,omitempty" yaml:"props,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/cloud.redhat.com_frontends.yaml
+++ b/config/crd/bases/cloud.redhat.com_frontends.yaml
@@ -120,6 +120,8 @@ spec:
                                 type: boolean
                               pathname:
                                 type: string
+                              props:
+                                x-kubernetes-preserve-unknown-fields: true
                             required:
                             - pathname
                             type: object

--- a/deploy.yml
+++ b/deploy.yml
@@ -541,6 +541,8 @@ objects:
                                   type: boolean
                                 pathname:
                                   type: string
+                                props:
+                                  x-kubernetes-preserve-unknown-fields: true
                               required:
                               - pathname
                               type: object

--- a/docs/antora/modules/ROOT/pages/api_reference.adoc
+++ b/docs/antora/modules/ROOT/pages/api_reference.adoc
@@ -472,6 +472,7 @@ FrontendSpec defines the desired state of Frontend
 | *`pathname`* __string__ | 
 | *`dynamic`* __boolean__ | 
 | *`exact`* __boolean__ | 
+| *`props`* __JSON__ |
 |===
 
 


### PR DESCRIPTION
### Description

Some of the applications have in their navigation props to identify which bundle is active. This PR add such option to be consumed by frontend operator in order to properly surface these applications.

[learning resources](https://github.com/RedHatInsights/chrome-service-backend/blob/main/static/beta/stage/modules/fed-modules.json#L45-L82) module for reference.