### PR TITLE
Containerized Builds Dockerfile and Go version bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18.4-8.1669838000 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.19.9-2.1687187497 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.19.9-2.1687187497 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.19.9-2.1687187497 as buildergo
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.19.9-2.1687187497 as buildergo
+FROM registry.access.redhat.com/ubi8/go-toolset:1.19.9-2.1687187497 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,22 @@
+# Build the manager binary
+FROM registry.access.redhat.com/ubi8/go-toolset:1.19.9-2.1687187497 as builder
+
+WORKDIR /workspace
+
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+RUN go mod download
+
+COPY main.go main.go
+COPY api/ api/
+COPY controllers/ controllers/
+
+USER 0
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o manager main.go
+
+RUN rm main.go
+RUN rm -rf api
+RUN rm -rf controllers
+

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/RedHatInsights/frontend-operator
 
-go 1.17
+go 1.19
 
 require (
 	github.com/RedHatInsights/clowder v0.50.0

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,6 @@ github.com/RedHatInsights/clowder v0.50.0 h1:Jrzpo5uY9ghsrR4DeMsDnyR7EGZYAVjXBt4
 github.com/RedHatInsights/clowder v0.50.0/go.mod h1:sY0IIuVDz/PN7l+R/8MfH51V0t72IKVEwxU+DwluG14=
 github.com/RedHatInsights/go-difflib v1.0.0 h1:BoruyjZfxO81sEynhkG6c4SMAQOjuBWezcJxtGK8dyw=
 github.com/RedHatInsights/go-difflib v1.0.0/go.mod h1:UMKOFdypYfrKT1B1nbGodM09nhOiAmcjes8qWP7Myrs=
-github.com/RedHatInsights/rhc-osdk-utils v0.6.2 h1:VXTqk6VHrsaEPSw3N95rCq+g0y2LR7t9Za0wBS2/RyA=
-github.com/RedHatInsights/rhc-osdk-utils v0.6.2/go.mod h1:MQoUQGaVjM25JsownEKKa2Tef0qnJOm1ljocaQ0nx40=
 github.com/RedHatInsights/rhc-osdk-utils v0.7.0 h1:KgOiw2nKS26RuiSRVWVHtXNPx23VMspuB0bLCLIAlTs=
 github.com/RedHatInsights/rhc-osdk-utils v0.7.0/go.mod h1:MQoUQGaVjM25JsownEKKa2Tef0qnJOm1ljocaQ0nx40=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=


### PR DESCRIPTION
This patch starts the process of adding containerized builds. It adds a new Dockerfile.base modelled after Clowder's. While I was in here it made sense to upgrade to go 1.19.