### PR TITLE
forgot dot in build

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -37,7 +37,7 @@ if [[ "$VALID_TAGS_LENGTH" -eq 0 ]]; then
     docker --config="$DOCKER_CONF" build -f Dockerfile.base . -t "$BASE_IMG"
 	docker --config="$DOCKER_CONF" push "$BASE_IMG"
 fi
-docker --config="$DOCKER_CONF" build  --build-arg BASE_IMAGE="$BASE_IMG" -t "${IMAGE}:${IMAGE_TAG}"
+docker --config="$DOCKER_CONF" build  --build-arg BASE_IMAGE="$BASE_IMG" -t "${IMAGE}:${IMAGE_TAG}" .
 #### End 
 
 docker --config="$DOCKER_CONF" build  --build-arg BASE_IMAGE="$BASE_IMG" -t "${IMAGE}:${IMAGE_TAG}" .

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -37,7 +37,6 @@ if [[ "$VALID_TAGS_LENGTH" -eq 0 ]]; then
     docker --config="$DOCKER_CONF" build -f Dockerfile.base . -t "$BASE_IMG"
 	docker --config="$DOCKER_CONF" push "$BASE_IMG"
 fi
-docker --config="$DOCKER_CONF" build  --build-arg BASE_IMAGE="$BASE_IMG" -t "${IMAGE}:${IMAGE_TAG}" .
 #### End 
 
 docker --config="$DOCKER_CONF" build  --build-arg BASE_IMAGE="$BASE_IMG" -t "${IMAGE}:${IMAGE_TAG}" .


### PR DESCRIPTION
https://ci.ext.devshift.net/job/RedHatInsights-frontend-operator-gh-build-main/130/console failed with 

```
15:34:21 + docker --config=/var/lib/jenkins/workspace/RedHatInsights-frontend-operator-gh-build-main/.docker build --build-arg BASE_IMAGE=quay.io/cloudservices/frontend-operator-build-base:d9e6758b -t quay.io/cloudservices/frontend-operator:8574edc
15:34:21 ERROR: "docker buildx build" requires exactly 1 argument.
15:34:21 See 'docker buildx build --help'.
15:34:21 
```

So I think this will fix that