### PR TITLE
Bump UBI8 go-toolset deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY controllers/ controllers/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o manager main.go
 
-FROM registry.access.redhat.com/ubi8/go-toolset:1.19.9-2.1687187497
+FROM registry.access.redhat.com/ubi8/go-toolset:1.19.10-10 
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65534:65534

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.19.9-2.1687187497 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.19.10-10  as builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
This patch updates the docker base images