### PR TITLE
Build arm64 and amd64 versions and use multi-arch manifest on quay.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -o manager main.go
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
 WORKDIR /

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -14,7 +14,7 @@ COPY controllers/ controllers/
 
 USER 0
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -o manager main.go
 
 RUN rm main.go
 RUN rm -rf api

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -39,5 +39,11 @@ if [[ "$VALID_TAGS_LENGTH" -eq 0 ]]; then
 fi
 #### End 
 
-docker --config="$DOCKER_CONF" build  --build-arg BASE_IMAGE="$BASE_IMG" -t "${IMAGE}:${IMAGE_TAG}" .
-docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
+docker --config="$DOCKER_CONF" build --platform linux/amd64  --build-arg BASE_IMAGE="$BASE_IMG" --build-arg GOARCH="amd64" -t "${IMAGE}:${IMAGE_TAG}-amd64" --push .
+docker --config="$DOCKER_CONF" build --platform linux/arm64  --build-arg BASE_IMAGE="$BASE_IMG" --build-arg GOARCH="arm64" -t "${IMAGE}:${IMAGE_TAG}-arm64" --push .
+
+docker --config="$DOCKER_CONF" manifest create "${IMAGE}:${IMAGE_TAG}" \
+    "${IMAGE}:${IMAGE_TAG}-amd64" \
+    "${IMAGE}:${IMAGE_TAG}-arm64"
+
+docker --config="$DOCKER_CONF" manifest push "${IMAGE}:${IMAGE_TAG}"


### PR DESCRIPTION
This patch allows for multi-arch builds for arm64 and amd64.