### PR TITLE
Added required params for deprecated-image-check migration

### DIFF
--- a/.tekton/frontend-operator-pull-request.yaml
+++ b/.tekton/frontend-operator-pull-request.yaml
@@ -320,6 +320,10 @@ spec:
       params:
       - name: BASE_IMAGES_DIGESTS
         value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      - name: IMAGE_URL
+        value: $(tasks.build-container.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
       runAfter:
       - build-container
       taskRef:

--- a/.tekton/frontend-operator-push.yaml
+++ b/.tekton/frontend-operator-push.yaml
@@ -274,6 +274,10 @@ spec:
       params:
       - name: BASE_IMAGES_DIGESTS
         value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      - name: IMAGE_URL
+        value: $(tasks.build-container.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
       runAfter:
       - build-container
       taskRef:


### PR DESCRIPTION
Update tekton pipelines to support new deprecated-base-image-check migration.
https://github.com/redhat-appstudio/build-definitions/blob/main/task/deprecated-image-check/0.4/MIGRATION.md