### PR TITLE
refactor-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,21 +24,10 @@ jobs:
         name: Checkout frontend-operator
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest
-
-          args: >
-            --enable=errcheck,gocritic,gofmt,goimports,gosec,gosimple,govet,ineffassign,revive,staticcheck,typecheck,unused,bodyclose
-            --fix=false
-            --max-same-issues=20
-            --out-${NO_FUTURE}format=colored-line-number
-            --print-issued-lines=true
-            --print-linter-name=true
-            --sort-results=true
-            --timeout=5m0s
-            --uniq-by-line=false
           # Optional: working directory, useful for monorepos
           # working-directory: somedir
 
@@ -46,7 +35,7 @@ jobs:
           # args: --issues-exit-code=0
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
-          only-new-issues: false
+#          only-new-issues: false
 
           # Optional: if set to true then the all caching functionality will be complete disabled,
           #           takes precedence over all other caching options.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,75 @@
+linters:
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    - errcheck
+    - gocritic
+    - gofmt
+    - goimports
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - revive
+    - staticcheck
+    - typecheck
+    - unused
+    - bodyclose
 issues:
   exclude-rules:
     - path: api/v1alpha1/groupversion_info.go
       linters:
         - gofmt
         - goimports
+  # Fix found issues (if it's supported by the linter).
+  # Default: false
+  # fix: true
+
+  # Maximum count of issues with the same text.
+  # Set to 0 to disable.
+  # Default: 3
+  max-same-issues: 20
+
+output:
+# The formats used to render issues.
+# Formats:
+# - `colored-line-number`
+# - `line-number`
+# - `json`
+# - `colored-tab`
+# - `tab`
+# - `html`
+# - `checkstyle`
+# - `code-climate`
+# - `junit-xml`
+# - `github-actions`
+# - `teamcity`
+# - `sarif`
+# Output path can be either `stdout`, `stderr` or path to the file to write to.
+#
+# For the CLI flag (`--out-format`), multiple formats can be specified by separating them by comma.
+# The output can be specified for each of them by separating format name and path by colon symbol.
+# Example: "--out-format=checkstyle:report.xml,json:stdout,colored-line-number"
+# The CLI flag (`--out-format`) override the configuration file.
+#
+# Default:
+#  formats:
+#    - format: colored-line-number
+#      path: stdout
+# Print lines of code with issue.
+# Default: true
+#  print-issued-lines: false
+# Print linter name in the end of issue text.
+# Default: true
+#  print-linter-name: false
+# Sort results by the order defined in `sort-order`.
+# Default: false
+  sort-results: true
+# Make issues output unique by line.
+# Default: true
+  uniq-by-line: false
+
+run:
+  # Timeout for analysis, e.g. 30s, 5m.
+  # Default: 1m
+  timeout: 5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,19 +1,19 @@
 linters:
   # Enable specific linter
-  # https://golangci-lint.run/usage/linters/#enabled-by-default
   enable:
-    - errcheck
+# https://golangci-lint.run/usage/linters/#enabled-by-default
+#    - errcheck
+#    - gosimple
+#    - govet
+#    - ineffassign
+#    - staticcheck
+#    - unused
     - gocritic
     - gofmt
     - goimports
     - gosec
-    - gosimple
-    - govet
-    - ineffassign
     - revive
-    - staticcheck
     - typecheck
-    - unused
     - bodyclose
 issues:
   exclude-rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,10 @@ linters:
     - revive
     - typecheck
     - bodyclose
+linters-settings:
+  gosec:
+    excludes:
+      - G115
 issues:
   exclude-rules:
     - path: api/v1alpha1/groupversion_info.go

--- a/Makefile
+++ b/Makefile
@@ -250,3 +250,6 @@ catalog-push: ## Push a catalog image.
 
 clean:
 	rm -r $(TESTBIN_DIR)
+
+lint:
+	golangci-lint run

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"math"
 
 	"github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/errors"
 	crd "github.com/RedHatInsights/frontend-operator/api/v1alpha1"
@@ -53,6 +54,7 @@ func SetFrontendConditions(ctx context.Context, client client.Client, o *crd.Fro
 
 	condition.Type = crd.FrontendsReady
 	condition.LastTransitionTime = metav1.Now()
+	//FIXME: condition is always false
 	if err != nil {
 		condition.Message += err.Error()
 		condition.Reason = "Error"
@@ -112,7 +114,15 @@ func GetFrontendFigures(ctx context.Context, client client.Client, o *crd.Fronte
 		return crd.FrontendDeployments{}, "", errors.Wrap("count resources: ", err)
 	}
 
+	if results.Managed < math.MinInt32 || results.Managed > math.MaxInt32 {
+		return crd.FrontendDeployments{}, "", errors.NewClowderError("value out of range for int32")
+	}
 	deploymentStats.ManagedDeployments = int32(results.Managed)
+
+	if results.Ready < math.MinInt32 || results.Ready > math.MaxInt32 {
+		return crd.FrontendDeployments{}, "", errors.NewClowderError("value out of range for int32")
+	}
 	deploymentStats.ReadyDeployments = int32(results.Ready)
+
 	return deploymentStats, results.BrokenMessage, nil
 }


### PR DESCRIPTION
This PR aims to:
- refactor the linter config out of the GHA and into a file so that the same config is usable outside of GHA
- add a lint target to run lints using make
- fix the issues the linter found

**UPDATE**: need to disable G115 from `gosec` since the linter still complains after applying and apparently valid fix. will revisit as securego/gosec#1212 gets fixed