### PR TITLE
Add new kuttl test for fully fledged frontend config

### DIFF
--- a/tests/e2e/full-frontend/00-create-namespace.yaml
+++ b/tests/e2e/full-frontend/00-create-namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-full-app
+spec:
+  finalizers:
+  - kubernetes

--- a/tests/e2e/full-frontend/01-create-resources.yaml
+++ b/tests/e2e/full-frontend/01-create-resources.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: FrontendEnvironment
+metadata:
+  name: test-full-app-environment
+spec:
+  generateNavJSON: false
+  ssl: false
+  hostname: foo.redhat.com
+  sso: https://sso.foo.redhat.com
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: Frontend
+metadata:
+  name: chrome
+  namespace: test-full-app
+spec:
+  API:
+    versions:
+      - v1
+  frontend:
+    paths:
+      - /
+  deploymentRepo: https://github.com/RedHatInsights/insights-chrome
+  envName: test-full-app-environment
+  image: quay.io/cloudservices/insights-chrome-frontend:720317c
+  serviceTiles:
+        - section: "section1"
+          group: "group"
+          id: "id"
+          href: "www.redhat.com"
+          title: "Service 1"
+          icon: "icon.png"
+          isExternal: true
+        - section: "section2"
+          group: "group"
+          id: "id2"
+          href: "www.redhat.com"
+          title: "Service 2"
+          icon: "icon.png"
+  searchEntries:
+      - id: "id1"
+        href: "www.redhat.com"
+        title: "Search Result 1"
+        description: "the quick brown fox"
+        alt_title:
+          - "foo"
+        isExternal: true
+      - id: "id2"
+        href: "www.redhat.com"
+        title: "Search Result 2"
+        description: "lorem ipsum"
+        alt_title:
+          - "foo"
+          - "bar"
+        isExternal: true
+  widgetRegistry:
+      - scope: "foobar"
+        module: "./RootApp"
+        config:
+          icon: "icon.png"
+          title: "Widget Title"
+      - scope: "foobar"
+        module: "./OtherApp"
+        config:
+          icon: "icon.png"
+          title: "Other Widget Title"
+          headerLink:
+            href: "www.redhat.com"
+            title: "Redhat Site"
+          permissions:
+              - method: withEmail
+                args:
+                  - "@redhat.com"
+                  - 2
+              - method: isOrgAdmin
+  module:
+    config:
+      ssoUrl: 'https://'
+    manifestLocation: /apps/chrome/js/fed-mods.json
+    modules:
+        - id: "landing"
+          module: "./RootApp"
+          routes:
+          - pathname: /
+            exact: true
+            permissions:
+                - method: withEmail
+                  args:
+                    - "@redhat.com"
+                    - 2
+        - id: "landingFoo"
+          module: "./OtherApp"
+          routes:
+          - pathname: /
+            exact: true
+  title: Chrome
+

--- a/tests/e2e/full-frontend/02-assert.yaml
+++ b/tests/e2e/full-frontend/02-assert.yaml
@@ -1,0 +1,49 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: chrome-frontend
+  namespace: test-full-app
+  labels:
+    frontend: chrome
+  ownerReferences:
+    - apiVersion: cloud.redhat.com/v1alpha1
+      kind: Frontend
+      name: chrome
+spec:
+  selector:
+    matchLabels:
+      frontend: chrome
+  template:
+    spec:
+      volumes:
+        - name: config
+          configMap:
+            name:  test-full-app-environment
+            defaultMode: 420
+      containers:
+        - name: fe-image
+          image: 'quay.io/cloudservices/insights-chrome-frontend:720317c'
+          ports:
+            - name: web
+              containerPort: 80
+              protocol: TCP
+            - name: metrics
+              containerPort: 9000
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /opt/app-root/src/build/stable/operator-generated
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: test-full-app-environment
+  namespace: test-full-app
+  labels:
+    frontendenv: test-full-app-environment
+  ownerReferences:
+    - apiVersion: cloud.redhat.com/v1alpha1
+      name: test-full-app-environment
+data:
+  fed-modules.json: '{"chrome":{"manifestLocation":"/apps/chrome/js/fed-mods.json","modules":[{"id":"landing","module":"./RootApp","routes":[{"pathname":"/","exact":true,"permissions":[{"method":"withEmail","args":["@redhat.com",2]}]}]},{"id":"landingFoo","module":"./OtherApp","routes":[{"pathname":"/","exact":true}]}],"config":{"ssoUrl":"https://sso.foo.redhat.com"},"fullProfile":false}}'


### PR DESCRIPTION
Depends on https://github.com/RedHatInsights/frontend-operator/pull/196 and the previous PRs @Hyperkid123 and I have already merged in. 

This new test should flush out all the additional *optional* fields on a frontend resource. I want to keep both tests (basic-frontend) and this ensures we do not accidentally enforce new required fields if unnecessary. 