### PR TITLE
Remove obsolete konflux references.

### DIFF
--- a/.tekton/frontend-operator-pull-request.yaml
+++ b/.tekton/frontend-operator-pull-request.yaml
@@ -286,8 +286,6 @@ spec:
       params:
       - name: BINARY_IMAGE
         value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:
       - build-container
       taskRef:
@@ -313,8 +311,6 @@ spec:
         workspace: workspace
     - name: deprecated-base-image-check
       params:
-      - name: BASE_IMAGES_DIGESTS
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       - name: IMAGE_URL
         value: $(tasks.build-container.results.IMAGE_URL)
       - name: IMAGE_DIGEST

--- a/.tekton/frontend-operator-push.yaml
+++ b/.tekton/frontend-operator-push.yaml
@@ -240,8 +240,6 @@ spec:
       params:
       - name: BINARY_IMAGE
         value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:
       - build-container
       taskRef:
@@ -267,8 +265,6 @@ spec:
         workspace: workspace
     - name: deprecated-base-image-check
       params:
-      - name: BASE_IMAGES_DIGESTS
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       - name: IMAGE_URL
         value: $(tasks.build-container.results.IMAGE_URL)
       - name: IMAGE_DIGEST


### PR DESCRIPTION
The `BASE_IMAGES_DIGESTS ` is an old reference that is no longer part of the build env. Fixes:
```
invalid result reference in pipeline task "build-source-image": "BASE_IMAGES_DIGESTS" is not a named result returned by pipeline task "build-container"
```

Unblocks #202 