### PR TITLE
Extend pre-cache-bust delay and add support for arbitrary URLs

### DIFF
--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -226,11 +226,17 @@ func createCachePurgePathList(frontend *crd.Frontend, frontendEnvironment *crd.F
 	if frontend.Spec.AkamaiCacheBustPaths != nil {
 		purgePaths = make([]string, 0, len(frontend.Spec.AkamaiCacheBustPaths))
 		for _, path := range frontend.Spec.AkamaiCacheBustPaths {
-			// Ensure each path has a leading slash but no double slashes
-			if !strings.HasPrefix(path, "/") {
-				path = "/" + path
+			// Check if path is a full URL (starts with "http://" or "https://")
+			if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+				// Add full URL path directly
+				purgePaths = append(purgePaths, path)
+			} else {
+				// Ensure each path has a leading slash but no double slashes
+				if !strings.HasPrefix(path, "/") {
+					path = "/" + path
+				}
+				purgePaths = append(purgePaths, purgeHost+path)
 			}
-			purgePaths = append(purgePaths, purgeHost+path)
 		}
 	}
 	return purgePaths

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -222,21 +222,22 @@ func createCachePurgePathList(frontend *crd.Frontend, frontendEnvironment *crd.F
 	// Initialize with a default path if AkamaiCacheBustPaths is nil
 	purgePaths := []string{fmt.Sprintf("%s/apps/%s/fed-mods.json", purgeHost, frontend.Name)}
 
-	// If custom paths are provided, construct the purge paths list
-	if frontend.Spec.AkamaiCacheBustPaths != nil {
-		purgePaths = make([]string, 0, len(frontend.Spec.AkamaiCacheBustPaths))
-		for _, path := range frontend.Spec.AkamaiCacheBustPaths {
-			// Check if path is a full URL (starts with "http://" or "https://")
-			if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
-				// Add full URL path directly
-				purgePaths = append(purgePaths, path)
-			} else {
-				// Ensure each path has a leading slash but no double slashes
-				if !strings.HasPrefix(path, "/") {
-					path = "/" + path
-				}
-				purgePaths = append(purgePaths, purgeHost+path)
+	if frontend.Spec.AkamaiCacheBustPaths == nil {
+		return purgePaths 
+	}
+
+	purgePaths = make([]string, 0, len(frontend.Spec.AkamaiCacheBustPaths))
+	for _, path := range frontend.Spec.AkamaiCacheBustPaths {
+		// Check if path is a full URL (starts with "http://" or "https://")
+		if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+			// Add full URL path directly
+			purgePaths = append(purgePaths, path)
+		} else {
+			// Ensure each path has a leading slash but no double slashes
+			if !strings.HasPrefix(path, "/") {
+				path = "/" + path
 			}
+			purgePaths = append(purgePaths, purgeHost+path)
 		}
 	}
 	return purgePaths

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -223,7 +223,7 @@ func createCachePurgePathList(frontend *crd.Frontend, frontendEnvironment *crd.F
 	purgePaths := []string{fmt.Sprintf("%s/apps/%s/fed-mods.json", purgeHost, frontend.Name)}
 
 	if frontend.Spec.AkamaiCacheBustPaths == nil {
-		return purgePaths 
+		return purgePaths
 	}
 
 	purgePaths = make([]string, 0, len(frontend.Spec.AkamaiCacheBustPaths))

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -216,33 +216,22 @@ func makeAkamaiEdgercFileFromSecret(secret *v1.Secret) string {
 }
 
 func createCachePurgePathList(frontend *crd.Frontend, frontendEnvironment *crd.FrontendEnvironment) []string {
-	var purgeHost string
-	// If the cache bust URL doesn't begin with https:// then add it
-	if strings.HasPrefix(frontendEnvironment.Spec.AkamaiCacheBustURL, "https://") {
-		purgeHost = frontendEnvironment.Spec.AkamaiCacheBustURL
-	} else {
-		purgeHost = fmt.Sprintf("https://%s", frontendEnvironment.Spec.AkamaiCacheBustURL)
-	}
+	// Set purgeHost by ensuring the URL begins with https:// and has no trailing /
+	purgeHost := strings.TrimSuffix(fmt.Sprintf("https://%s", strings.TrimPrefix(frontendEnvironment.Spec.AkamaiCacheBustURL, "https://")), "/")
 
-	// If purgeHost ends with a / then remove it
-	purgeHost = strings.TrimSuffix(purgeHost, "/")
+	// Initialize with a default path if AkamaiCacheBustPaths is nil
+	purgePaths := []string{fmt.Sprintf("%s/apps/%s/fed-mods.json", purgeHost, frontend.Name)}
 
-	// If there is no purge list return the default
-	if frontend.Spec.AkamaiCacheBustPaths == nil {
-		return []string{fmt.Sprintf("%s/apps/%s/fed-mods.json", purgeHost, frontend.Name)}
-	}
-
-	purgePaths := []string{}
-	// Loop through the frontend purge paths and append them to the purge host
-	for _, path := range frontend.Spec.AkamaiCacheBustPaths {
-		var purgePath string
-		// If the path doesn't begin with a / then add it
-		if strings.HasPrefix(path, "/") {
-			purgePath = fmt.Sprintf("%s%s", purgeHost, path)
-		} else {
-			purgePath = fmt.Sprintf("%s/%s", purgeHost, path)
+	// If custom paths are provided, construct the purge paths list
+	if frontend.Spec.AkamaiCacheBustPaths != nil {
+		purgePaths = make([]string, 0, len(frontend.Spec.AkamaiCacheBustPaths))
+		for _, path := range frontend.Spec.AkamaiCacheBustPaths {
+			// Ensure each path has a leading slash but no double slashes
+			if !strings.HasPrefix(path, "/") {
+				path = "/" + path
+			}
+			purgePaths = append(purgePaths, purgeHost+path)
 		}
-		purgePaths = append(purgePaths, purgePath)
 	}
 	return purgePaths
 }
@@ -302,7 +291,7 @@ func (r *FrontendReconciliation) populateCacheBustContainer(j *batchv1.Job) erro
 	pathsToCacheBust := createCachePurgePathList(r.Frontend, r.FrontendEnvironment)
 
 	// Construct the akamai cache bust command
-	command := fmt.Sprintf("sleep 60; /cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc delete %s", strings.Join(pathsToCacheBust, " "))
+	command := fmt.Sprintf("sleep 120; /cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc delete %s", strings.Join(pathsToCacheBust, " "))
 
 	// Modify the obejct to set the things we care about
 	cacheBustContainer := v1.Container{

--- a/tests/e2e/cachebust/01-create-resources.yaml
+++ b/tests/e2e/cachebust/01-create-resources.yaml
@@ -27,6 +27,7 @@ spec:
   akamaiCacheBustPaths:
     - /config/chrome/fed-modules.json
     - apps/chrome/index.html
+    - https://app.company.com
   deploymentRepo: https://github.com/RedHatInsights/insights-chrome
   envName: test-cachebust-environment
   image: quay.io/cloudservices/insights-chrome-frontend:720317c

--- a/tests/e2e/cachebust/02-assert.yaml
+++ b/tests/e2e/cachebust/02-assert.yaml
@@ -69,7 +69,7 @@ spec:
           command:
             - /bin/bash
             - '-c'
-            - 'sleep 60; /cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc delete https://console.doesntexist.redhat.com/config/chrome/fed-modules.json https://console.doesntexist.redhat.com/apps/chrome/index.html'
+            - 'sleep 120; /cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc delete https://console.doesntexist.redhat.com/config/chrome/fed-modules.json https://console.doesntexist.redhat.com/apps/chrome/index.html'
           resources: {}
           volumeMounts:
             - name: akamai-edgerc
@@ -148,7 +148,7 @@ spec:
           command:
             - /bin/bash
             - '-c'
-            - 'sleep 60; /cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc delete https://console.doesntexist.redhat.com/apps/chrome-test-defaults/fed-mods.json'
+            - 'sleep 120; /cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc delete https://console.doesntexist.redhat.com/apps/chrome-test-defaults/fed-mods.json'
           resources: {}
           volumeMounts:
             - name: akamai-edgerc

--- a/tests/e2e/cachebust/02-assert.yaml
+++ b/tests/e2e/cachebust/02-assert.yaml
@@ -69,7 +69,7 @@ spec:
           command:
             - /bin/bash
             - '-c'
-            - 'sleep 120; /cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc delete https://console.doesntexist.redhat.com/config/chrome/fed-modules.json https://console.doesntexist.redhat.com/apps/chrome/index.html'
+            - 'sleep 120; /cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc delete https://console.doesntexist.redhat.com/config/chrome/fed-modules.json https://console.doesntexist.redhat.com/apps/chrome/index.html https://app.company.com'
           resources: {}
           volumeMounts:
             - name: akamai-edgerc

--- a/tests/e2e/cachebust/04-assert.yaml
+++ b/tests/e2e/cachebust/04-assert.yaml
@@ -69,7 +69,7 @@ spec:
           command:
             - /bin/bash
             - '-c'
-            - 'sleep 60; /cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc delete https://console.doesntexist.redhat.com/config/chrome/fed-modules.json https://console.doesntexist.redhat.com/apps/chrome/index.html'
+            - 'sleep 120; /cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc delete https://console.doesntexist.redhat.com/config/chrome/fed-modules.json https://console.doesntexist.redhat.com/apps/chrome/index.html'
           resources: {}
           volumeMounts:
             - name: akamai-edgerc
@@ -148,7 +148,7 @@ spec:
           command:
             - /bin/bash
             - '-c'
-            - 'sleep 60; /cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc delete https://console.doesntexist.redhat.com/apps/chrome-test-defaults/fed-mods.json'
+            - 'sleep 120; /cli/.akamai-cli/src/cli-purge/bin/akamai-purge --edgerc /opt/app-root/edgerc delete https://console.doesntexist.redhat.com/apps/chrome-test-defaults/fed-mods.json'
           resources: {}
           volumeMounts:
             - name: akamai-edgerc


### PR DESCRIPTION
This change does the following:

- Increase the timeout before busting cache to two minutes
- Add the ability to provide full arbitrary URLs to cache bust