### PR TITLE
Add feoConfigEnabled bool to frontend spec for feo self service

### DIFF
--- a/api/v1alpha1/frontend_types.go
+++ b/api/v1alpha1/frontend_types.go
@@ -130,6 +130,8 @@ type FrontendSpec struct {
 	// Data for the available widgets for the resource
 	WidgetRegistry []*WidgetEntry `json:"widgetRegistry,omitempty" yaml:"widgetRegistry,omitempty"`
 	Replicas       *int32         `json:"replicas,omitempty" yaml:"replicas,omitempty"`
+	// Injects configuration from application when enabled
+	FeoConfigEnabled bool `json:"feoConfigEnabled,omitempty" yaml:"feoConfigEnabled,omitempty"`
 }
 
 var ReconciliationSuccessful = "ReconciliationSuccessful"

--- a/config/crd/bases/cloud.redhat.com_frontends.yaml
+++ b/config/crd/bases/cloud.redhat.com_frontends.yaml
@@ -79,6 +79,9 @@ spec:
                 type: boolean
               envName:
                 type: string
+              feoConfigEnabled:
+                description: Injects configuration from application when enabled
+                type: boolean
               frontend:
                 properties:
                   paths:

--- a/controllers/frontend_controller_suite_test.go
+++ b/controllers/frontend_controller_suite_test.go
@@ -437,7 +437,6 @@ var _ = ginkgo.Describe("Frontend controller with chrome", func() {
 						}},
 						Config: &customConfig,
 					},
-					FeoConfigEnabled: true,
 				},
 			}
 			gomega.Expect(k8sClient.Create(ctx, frontend)).Should(gomega.Succeed())

--- a/controllers/frontend_controller_suite_test.go
+++ b/controllers/frontend_controller_suite_test.go
@@ -84,6 +84,7 @@ var _ = ginkgo.Describe("Frontend controller with image", func() {
 						}},
 						Config: &customConfig,
 					},
+					FeoConfigEnabled: true,
 				},
 			}
 			gomega.Expect(k8sClient.Create(ctx, frontend)).Should(gomega.Succeed())
@@ -126,6 +127,7 @@ var _ = ginkgo.Describe("Frontend controller with image", func() {
 						Config:      &customConfig2,
 						FullProfile: crd.FalsePtr(),
 					},
+					FeoConfigEnabled: true,
 				},
 			}
 			gomega.Expect(k8sClient.Create(ctx, frontend2)).Should(gomega.Succeed())
@@ -301,6 +303,7 @@ var _ = ginkgo.Describe("Frontend controller with service", func() {
 							}},
 						}},
 					},
+					FeoConfigEnabled: true,
 				},
 			}
 			gomega.Expect(k8sClient.Create(ctx, frontend)).Should(gomega.Succeed())
@@ -434,6 +437,7 @@ var _ = ginkgo.Describe("Frontend controller with chrome", func() {
 						}},
 						Config: &customConfig,
 					},
+					FeoConfigEnabled: true,
 				},
 			}
 			gomega.Expect(k8sClient.Create(ctx, frontend)).Should(gomega.Succeed())
@@ -474,6 +478,7 @@ var _ = ginkgo.Describe("Frontend controller with chrome", func() {
 						}},
 						Config: &customConfig,
 					},
+					FeoConfigEnabled: true,
 				},
 			}
 			gomega.Expect(k8sClient.Create(ctx, frontend2)).Should(gomega.Succeed())
@@ -513,6 +518,7 @@ var _ = ginkgo.Describe("Frontend controller with chrome", func() {
 							}},
 						}},
 					},
+					FeoConfigEnabled: true,
 				},
 			}
 			gomega.Expect(k8sClient.Create(ctx, frontend3)).Should(gomega.Succeed())
@@ -781,6 +787,7 @@ var _ = ginkgo.Describe("Dependencies", func() {
 							Dependencies: []string{"depstring"},
 						}},
 					},
+					FeoConfigEnabled: true,
 				},
 			}
 			gomega.Expect(k8sClient.Create(ctx, frontend)).Should(gomega.Succeed())
@@ -821,6 +828,7 @@ var _ = ginkgo.Describe("Dependencies", func() {
 							OptionalDependencies: []string{"depstring-op"},
 						}},
 					},
+					FeoConfigEnabled: true,
 				},
 			}
 			gomega.Expect(k8sClient.Create(ctx, frontend2)).Should(gomega.Succeed())
@@ -860,6 +868,7 @@ var _ = ginkgo.Describe("Dependencies", func() {
 							}},
 						}},
 					},
+					FeoConfigEnabled: true,
 				},
 			}
 			gomega.Expect(k8sClient.Create(ctx, frontend3)).Should(gomega.Succeed())
@@ -958,7 +967,8 @@ func frontendFromSearchEntry(tc SearchIndexCase, entry SearchFrontendEntry) *crd
 				ManifestLocation: "",
 				Modules:          []crd.Module{},
 			},
-			SearchEntries: entry.SearchEntries,
+			SearchEntries:    entry.SearchEntries,
+			FeoConfigEnabled: true,
 		},
 	}
 
@@ -1152,7 +1162,8 @@ func frontendFromWidget(wc WidgetCase, wf WidgetFrontendTestEntry) *crd.Frontend
 				ManifestLocation: "",
 				Modules:          []crd.Module{},
 			},
-			WidgetRegistry: wf.Widgets,
+			WidgetRegistry:   wf.Widgets,
+			FeoConfigEnabled: true,
 		},
 	}
 	return frontend
@@ -1300,7 +1311,8 @@ func frontendFromServiceTile(sct ServiceTileCase, ste ServiceTileTestEntry) *crd
 				ManifestLocation: "",
 				Modules:          []crd.Module{},
 			},
-			ServiceTiles: ste.ServiceTiles,
+			ServiceTiles:     ste.ServiceTiles,
+			FeoConfigEnabled: true,
 		},
 	}
 	return frontend

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -755,7 +755,7 @@ func defaultNetSpec(ingressClass, host string, ingressPaths []networking.HTTPIng
 
 func setupFedModules(feEnv *crd.FrontendEnvironment, frontendList *crd.FrontendList, fedModules map[string]crd.FedModule) error {
 	for _, frontend := range frontendList.Items {
-		if frontend.Spec.Module != nil {
+		if frontend.Spec.FeoConfigEnabled && frontend.Spec.Module != nil {
 			// module names in fed-modules.json must be camelCase
 			// K8s does not allow camelCase names, only
 			// whatever-this-case-is, so we convert.
@@ -829,7 +829,7 @@ func adjustSearchEntry(searchEntry *crd.SearchEntry, frontend crd.Frontend) crd.
 func setupSearchIndex(feList *crd.FrontendList) []crd.SearchEntry {
 	searchIndex := []crd.SearchEntry{}
 	for _, frontend := range feList.Items {
-		if frontend.Spec.SearchEntries != nil {
+		if frontend.Spec.FeoConfigEnabled && frontend.Spec.SearchEntries != nil {
 			for _, searchEntry := range frontend.Spec.SearchEntries {
 				if searchEntry != nil {
 					searchIndex = append(searchIndex, adjustSearchEntry(searchEntry, frontend))
@@ -843,8 +843,10 @@ func setupSearchIndex(feList *crd.FrontendList) []crd.SearchEntry {
 func setupWidgetRegistry(feList *crd.FrontendList) []crd.WidgetEntry {
 	widgetRegistry := []crd.WidgetEntry{}
 	for _, frontend := range feList.Items {
-		for _, widget := range frontend.Spec.WidgetRegistry {
-			widgetRegistry = append(widgetRegistry, *widget)
+		if frontend.Spec.FeoConfigEnabled {
+			for _, widget := range frontend.Spec.WidgetRegistry {
+				widgetRegistry = append(widgetRegistry, *widget)
+			}
 		}
 	}
 
@@ -889,7 +891,7 @@ func setupServiceTilesData(feList *crd.FrontendList, feEnvironment crd.FrontendE
 
 	skippedTiles := []string{}
 	for _, frontend := range feList.Items {
-		if frontend.Spec.ServiceTiles != nil {
+		if frontend.Spec.FeoConfigEnabled && frontend.Spec.ServiceTiles != nil {
 			for _, tile := range frontend.Spec.ServiceTiles {
 				groupKey := getServiceTilePath(tile.Section, tile.Group)
 				if groupTiles, ok := tileGroupAccessMap[groupKey]; ok {

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -755,7 +755,7 @@ func defaultNetSpec(ingressClass, host string, ingressPaths []networking.HTTPIng
 
 func setupFedModules(feEnv *crd.FrontendEnvironment, frontendList *crd.FrontendList, fedModules map[string]crd.FedModule) error {
 	for _, frontend := range frontendList.Items {
-		if frontend.Spec.FeoConfigEnabled && frontend.Spec.Module != nil {
+		if (frontend.Name == "chrome" || frontend.Spec.FeoConfigEnabled) && frontend.Spec.Module != nil {
 			// module names in fed-modules.json must be camelCase
 			// K8s does not allow camelCase names, only
 			// whatever-this-case-is, so we convert.

--- a/deploy.yml
+++ b/deploy.yml
@@ -453,6 +453,9 @@ objects:
                   type: boolean
                 envName:
                   type: string
+                feoConfigEnabled:
+                  description: Injects configuration from application when enabled
+                  type: boolean
                 frontend:
                   properties:
                     paths:

--- a/tests/e2e/bundles/01-create-resources.yaml
+++ b/tests/e2e/bundles/01-create-resources.yaml
@@ -92,6 +92,7 @@ spec:
         routes:
           - pathname: /edge
     moduleID: edge
+  feoConfigEnabled: true
 ---
 apiVersion: cloud.redhat.com/v1alpha1
 kind: Bundle

--- a/tests/e2e/feo-config-flag-disabled/00-create-namespace.yaml
+++ b/tests/e2e/feo-config-flag-disabled/00-create-namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-feo-config-flag-namespace
+spec:
+  finalizers:
+  - kubernetes

--- a/tests/e2e/feo-config-flag-disabled/01-create-resources.yaml
+++ b/tests/e2e/feo-config-flag-disabled/01-create-resources.yaml
@@ -1,0 +1,150 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: FrontendEnvironment
+metadata:
+  name: test-feo-config-flag-namespace-environment
+spec:
+  generateNavJSON: true
+  ssl: false
+  hostname: foo.redhat.com
+  sso: https://sso.foo.redhat.com
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: Frontend
+metadata:
+  name: edge
+  namespace: test-feo-config-flag-namespace
+spec:
+  envName: test-feo-config-flag-namespace-environment
+  title: Edge
+  deploymentRepo: https://github.com/RedHatInsights/edge-frontend
+  API:
+    versions:
+      - v1
+  frontend:
+    paths:
+      - /apps/edge
+  image: "quay.io/cloudservices/edge-frontend:3244a17"
+  navItems:
+    - title: Inventory
+      expandable: true
+      routes:
+        - title: "Groups"
+          appId: "edge"
+          filterable: false
+          href: /edge/fleet-management
+          permissions:
+            - method: withEmail
+              args:
+                - "@redhat.com"
+                - "@sbb.ch"
+        - title: "Systems"
+          appId: "edge"
+          filterable: false
+          href: /edge/inventory
+          permissions:
+            - method: withEmail
+              args:
+                - "@redhat.com"
+                - "@sbb.ch"
+      permissions:
+        - method: withEmail
+          args:
+            - "@redhat.com"
+    - title: Manage Images
+      expandable: true
+      routes:
+        - title: "Images"
+          appId: "edge"
+          filterable: false
+          href: /edge/manage-images
+          permissions:
+            - method: withEmail
+              args:
+                - "@redhat.com"
+                - "@sbb.ch"
+        - title: "Custom Repositories"
+          appId: "edge"
+          filterable: false
+          href: /edge/repositories
+          permissions:
+            - method: withEmail
+              args:
+                - "@redhat.com"
+                - "@sbb.ch"
+      permissions:
+        - method: withEmail
+          args:
+            - "@redhat.com"
+            - "@sbb.ch"
+    - title: Learning Resources
+      href: /edge/learning-resources
+      permissions:
+        - method: withEmail
+          args:
+            - "@redhat.com"
+            - "@sbb.ch"
+  module:
+    manifestLocation: /apps/edge/fed-mods.json
+    modules:
+      - id: edge
+        module: ./RootApp
+        routes:
+          - pathname: /edge
+    moduleID: edge
+  serviceTiles:
+    - section: automation
+      group: ansible
+      id: ansible-link
+      title: Ansible FOO
+      href: /ansible/foo
+      description: Ansible FOO description thing
+      icon: AnsibleIcon
+    - section: iam
+      group: iam
+      id: iam-link
+      title: IAM FOO
+      href: /iam
+      description: Some Iam thing
+      icon: IAMIcon
+      isExternal: true
+  searchEntries:
+    - id: "landing"
+      title: "Landing"
+      href: /
+      description: "Landing page description"
+      alt_title:
+        - HCC Home page
+        - Home
+    - id: "landing-widgets"
+      title: "Widget fantastic"
+      href: /widgets
+      description: "Widget"
+  widgetRegistry:
+    - scope: "widgets"
+      module: "./RandomWidget"
+      config:
+        icon: "CogIcon"
+        title: "Random Widget"
+      defaults:
+        sm: 
+          w: 1
+          h: 1
+          maxH: 1
+          minH: 1
+        md: 
+          w: 1
+          h: 1
+          maxH: 1
+          minH: 1
+        lg: 
+          w: 1
+          h: 1
+          maxH: 1
+          minH: 1
+        xl: 
+          w: 1
+          h: 1
+          maxH: 1
+          minH: 1
+  feoConfigEnabled: false

--- a/tests/e2e/feo-config-flag-disabled/02-assert.yaml
+++ b/tests/e2e/feo-config-flag-disabled/02-assert.yaml
@@ -1,0 +1,14 @@
+# The config map should be present in the default namespace
+# however as FeoConfigEnabled is false - json should not be present
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: test-feo-config-flag-namespace-environment
+  namespace: test-feo-config-flag-namespace
+  labels:
+    frontendenv: test-feo-config-flag-namespace-environment
+  ownerReferences:
+    - apiVersion: cloud.redhat.com/v1alpha1
+      name: test-feo-config-flag-namespace-environment
+data:
+  fed-modules.json: '{}'

--- a/tests/e2e/generate-nav-json/01-create-resources.yaml
+++ b/tests/e2e/generate-nav-json/01-create-resources.yaml
@@ -29,4 +29,3 @@ spec:
       ssoUrl: 'https://'
     manifestLocation: /apps/chrome/js/fed-mods.json
   title: Chrome
-  feoConfigEnabled: true

--- a/tests/e2e/generate-nav-json/01-create-resources.yaml
+++ b/tests/e2e/generate-nav-json/01-create-resources.yaml
@@ -29,4 +29,4 @@ spec:
       ssoUrl: 'https://'
     manifestLocation: /apps/chrome/js/fed-mods.json
   title: Chrome
-
+  feoConfigEnabled: true

--- a/tests/e2e/generate-search-index/01-create-resources.yaml
+++ b/tests/e2e/generate-search-index/01-create-resources.yaml
@@ -38,5 +38,4 @@ spec:
     manifestLocation: /apps/search/fed-mods.json
     modules: []
     moduleID: search
-
-
+  feoConfigEnabled: true

--- a/tests/e2e/generate-service-tiles/01-create-resources.yaml
+++ b/tests/e2e/generate-service-tiles/01-create-resources.yaml
@@ -55,3 +55,4 @@ spec:
       description: Some Iam thing
       icon: IAMIcon
       isExternal: true
+  feoConfigEnabled: true

--- a/tests/e2e/generate-widget-registry/01-create-resources.yaml
+++ b/tests/e2e/generate-widget-registry/01-create-resources.yaml
@@ -53,5 +53,4 @@ spec:
     manifestLocation: /apps/widgets/fed-mods.json
     modules: []
     moduleID: widgets
-
-
+  feoConfigEnabled: true

--- a/tests/e2e/propagate-config-map/01-create-resources.yaml
+++ b/tests/e2e/propagate-config-map/01-create-resources.yaml
@@ -94,6 +94,7 @@ spec:
         routes:
           - pathname: /edge
     moduleID: edge
+  feoConfigEnabled: true
 ---
 apiVersion: cloud.redhat.com/v1alpha1
 kind: Bundle

--- a/tests/e2e/storage/01-create-resources.yaml
+++ b/tests/e2e/storage/01-create-resources.yaml
@@ -29,4 +29,5 @@ spec:
       ssoUrl: 'https://'
     manifestLocation: /apps/chrome/js/fed-mods.json
   title: Chrome
+  feoConfigEnabled: true
 

--- a/tests/e2e/storage/01-create-resources.yaml
+++ b/tests/e2e/storage/01-create-resources.yaml
@@ -29,5 +29,3 @@ spec:
       ssoUrl: 'https://'
     manifestLocation: /apps/chrome/js/fed-mods.json
   title: Chrome
-  feoConfigEnabled: true
-


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/RHCLOUD-35427

We have added a new _optional_  flag called `feoConfigEnabled` to the frontend spec that will allow for gradual consumption of all our tweaks to the operator by our tenant applications (as several of the tenant applications have very out of date modules and are missing the widgets, nav, etc. in their current `frontend.yaml`).

I have updated our existing tests to account for this new flag and have added a new kuttl test that ensures when the flag is false - none of the modules/widgets/service tiles/etc are synced into the config map. This should allow chrome service to use the config if it is present - or fall back to the legacy flow with minimal logic.

We did need to make an exception for chrome frontend in the fed-modules evaluation logic to ensure that our SSO URL is *always* set.