### PR TITLE
RHCLOUD-37627: Use volume mount to create caddyfiles for frontends (except chrome)

### DIFF
--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -90,7 +90,7 @@ func (r *FrontendReconciliation) run() error {
 	return nil
 }
 
-func populateContainerVolumeMounts(frontendEnvironment *crd.FrontendEnvironment) []v1.VolumeMount {
+func populateContainerVolumeMounts(frontendEnvironment *crd.FrontendEnvironment, frontend *crd.Frontend) []v1.VolumeMount {
 
 	volumeMounts := []v1.VolumeMount{}
 
@@ -111,6 +111,14 @@ func populateContainerVolumeMounts(frontendEnvironment *crd.FrontendEnvironment)
 		Name:      "config",
 		MountPath: "/opt/app-root/src/build/stable/operator-generated",
 	})
+
+	if frontend.Name != "chrome" {
+		volumeMounts = append(volumeMounts, v1.VolumeMount{
+			Name:      "caddy",
+			MountPath: "/opt/app-root/src/Caddyfile",
+			SubPath:   "Caddyfile",
+		})
+	}
 
 	// We generate SSL cert mounts conditionally
 	if frontendEnvironment.Spec.SSL {
@@ -149,7 +157,7 @@ func populateContainer(d *apps.Deployment, frontend *crd.Frontend, frontendEnvir
 				Protocol:      "TCP",
 			},
 		},
-		VolumeMounts: populateContainerVolumeMounts(frontendEnvironment),
+		VolumeMounts: populateContainerVolumeMounts(frontendEnvironment, frontend),
 		Resources: v1.ResourceRequirements{
 			Requests: v1.ResourceList{
 				v1.ResourceCPU:    resource.MustParse("30m"),
@@ -370,7 +378,7 @@ func (r *FrontendReconciliation) populateCacheBustContainer(j *batchv1.Job) erro
 }
 
 func populateVolumes(d *apps.Deployment, frontend *crd.Frontend, frontendEnvironment *crd.FrontendEnvironment) {
-	// By default we just want the config volume
+	// By default we just want the config and caddy volume
 	volumes := []v1.Volume{}
 	volumes = append(volumes, v1.Volume{
 		Name: "config",
@@ -379,6 +387,19 @@ func populateVolumes(d *apps.Deployment, frontend *crd.Frontend, frontendEnviron
 				LocalObjectReference: v1.LocalObjectReference{
 					Name: frontend.Spec.EnvName,
 				},
+			},
+		},
+	}, v1.Volume{
+		Name: "caddy",
+		VolumeSource: v1.VolumeSource{
+			ConfigMap: &v1.ConfigMapVolumeSource{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: frontend.Spec.EnvName,
+				},
+				Items: []v1.KeyToPath{{
+					Key:  "Caddyfile",
+					Path: "Caddyfile",
+				}},
 			},
 		},
 	})
@@ -1211,6 +1232,45 @@ func (r *FrontendReconciliation) setupBundleData(_ *v1.ConfigMap, _ map[string]c
 	return nil
 }
 
+func setupCaddyFile() string {
+	caddyFileContent := `
+	{
+		{$CADDY_TLS_MODE}
+		auto_https disable_redirects
+		servers {
+			metrics
+		}
+	}
+
+	:9000 {
+		metrics /metrics
+	}
+
+	:8000 {
+		{$CADDY_TLS_CERT}
+		header -Vary
+		log
+
+		# Handle main app route
+		@app_match {
+			path ${ROUTE_PATH}*
+		}
+		handle @app_match {
+			uri strip_prefix ${ROUTE_PATH}
+			file_server * {
+				root /srv/${OUTPUT_DIR}
+				browse
+			}
+		}
+
+		handle / {
+			redir /apps/chrome/index.html permanent
+		}
+	}
+	`
+	return caddyFileContent
+}
+
 func createConfigmapHash(cfgMap *v1.ConfigMap) (string, error) {
 	hashData, err := json.Marshal(cfgMap.Data)
 	if err != nil {
@@ -1279,15 +1339,15 @@ func (r *FrontendReconciliation) createConfigMap(nn types.NamespacedName, fronte
 		// Flag to trigger pod restart if config map changes
 		cfgMap.Annotations["qontract.recycle"] = "true"
 		/**
-				* to use config map in a pod as an env variable use following config:
-		    * podSpec:
-		    *   env:
-		    *    - name: FEO_SEARCH_INDEX
-		    *      valueFrom:
-		    *        configMapKeyRef:
-		    *          key: search-index.json # or other key from config map
-		    *          name: feo-context-cfg # based on the constant in the setupConfigMaps function
-			  *					 optional: true # because keys in configmap can be empty
+			* to use config map in a pod as an env variable use following config:
+		* podSpec:
+		*   env:
+		*    - name: FEO_SEARCH_INDEX
+		*      valueFrom:
+		*        configMapKeyRef:
+		*          key: search-index.json # or other key from config map
+		*          name: feo-context-cfg # based on the constant in the setupConfigMaps function
+		  *					 optional: true # because keys in configmap can be empty
 		*/
 	}
 
@@ -1377,6 +1437,7 @@ func (r *FrontendReconciliation) populateConfigMap(cfgMap *v1.ConfigMap, cacheMa
 	}
 
 	cfgMap.Data["fed-modules.json"] = string(fedModulesJSONData)
+	cfgMap.Data["Caddyfile"] = setupCaddyFile()
 	if len(searchIndex) > 0 {
 		cfgMap.Data["search-index.json"] = string(searchIndexJSONData)
 	}

--- a/controllers/templates/Caddyfile
+++ b/controllers/templates/Caddyfile
@@ -1,0 +1,33 @@
+{
+    {$CADDY_TLS_MODE}
+    auto_https disable_redirects
+    servers {
+        metrics
+    }
+}
+
+:9000 {
+    metrics /metrics
+}
+
+:8000 {
+    {$CADDY_TLS_CERT}
+    header -Vary
+    log
+
+    # Handle main app route
+    @app_match {
+        path ${ROUTE_PATH}*
+    }
+    handle @app_match {
+        uri strip_prefix ${ROUTE_PATH}
+        file_server * {
+            root /srv/${OUTPUT_DIR}
+            browse
+        }
+    }
+
+    handle / {
+        redir /apps/chrome/index.html permanent
+    }
+}

--- a/tests/e2e/basic-frontend/02-assert.yaml
+++ b/tests/e2e/basic-frontend/02-assert.yaml
@@ -21,6 +21,13 @@ spec:
           configMap:
             name:  test-basic-app-environment
             defaultMode: 420
+        - name: caddy
+          configMap:
+            name: test-basic-app-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
       containers:
         - name: fe-image
           image: 'quay.io/cloudservices/insights-chrome-frontend:720317c'

--- a/tests/e2e/bundles/02-assert.yaml
+++ b/tests/e2e/bundles/02-assert.yaml
@@ -21,6 +21,13 @@ spec:
           configMap:
             name: test-bundles-environment
             defaultMode: 420
+        - name: caddy
+          configMap:
+            name: test-bundles-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
       containers:
         - name: fe-image
           image: quay.io/cloudservices/edge-frontend:3244a17
@@ -36,6 +43,9 @@ spec:
               mountPath: /opt/app-root/src/build/chrome
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: caddy
+              mountPath: /opt/app-root/src/Caddyfile
+              subPath: Caddyfile
 ---
 apiVersion: cloud.redhat.com/v1alpha1
 kind: Bundle

--- a/tests/e2e/cachebust-multiple-urls/02-assert.yaml
+++ b/tests/e2e/cachebust-multiple-urls/02-assert.yaml
@@ -23,6 +23,13 @@ spec:
           configMap:
             name: test-cachebust-multiple-urls-environment
             defaultMode: 420
+        - name: caddy
+          configMap:
+            name: test-cachebust-multiple-urls-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
       containers:
         - name: fe-image
           image: quay.io/cloudservices/insights-chrome-frontend:720317c
@@ -37,6 +44,9 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: caddy
+              mountPath: /opt/app-root/src/Caddyfile
+              subPath: Caddyfile
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent
@@ -102,6 +112,13 @@ spec:
           configMap:
             name: test-cachebust-multiple-urls-environment
             defaultMode: 420
+        - name: caddy
+          configMap:
+            name: test-cachebust-multiple-urls-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
       containers:
         - name: fe-image
           image: quay.io/cloudservices/insights-chrome-frontend:720317c
@@ -116,6 +133,9 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: caddy
+              mountPath: /opt/app-root/src/Caddyfile
+              subPath: Caddyfile
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent
@@ -182,6 +202,13 @@ spec:
           configMap:
             name: test-cachebust-multiple-urls-environment
             defaultMode: 420
+        - name: caddy
+          configMap:
+            name: test-cachebust-multiple-urls-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
       containers:
         - name: fe-image
           image: quay.io/cloudservices/insights-chrome-frontend:720317c
@@ -196,3 +223,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: caddy
+              mountPath: /opt/app-root/src/Caddyfile
+              subPath: Caddyfile

--- a/tests/e2e/cachebust/02-assert.yaml
+++ b/tests/e2e/cachebust/02-assert.yaml
@@ -23,6 +23,13 @@ spec:
           configMap:
             name: test-cachebust-environment
             defaultMode: 420
+        - name: caddy
+          configMap:
+            name: test-cachebust-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
       containers:
         - name: fe-image
           image: quay.io/cloudservices/insights-chrome-frontend:720317c
@@ -37,6 +44,9 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: caddy
+              mountPath: /opt/app-root/src/Caddyfile
+              subPath: Caddyfile
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent
@@ -102,6 +112,13 @@ spec:
           configMap:
             name: test-cachebust-environment
             defaultMode: 420
+        - name: caddy
+          configMap:
+            name: test-cachebust-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
       containers:
         - name: fe-image
           image: quay.io/cloudservices/insights-chrome-frontend:720317c
@@ -116,6 +133,9 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: caddy
+              mountPath: /opt/app-root/src/Caddyfile
+              subPath: Caddyfile
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent
@@ -182,6 +202,13 @@ spec:
           configMap:
             name: test-cachebust-environment
             defaultMode: 420
+        - name: caddy
+          configMap:
+            name: test-cachebust-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
       containers:
         - name: fe-image
           image: quay.io/cloudservices/insights-chrome-frontend:720317c
@@ -196,3 +223,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: caddy
+              mountPath: /opt/app-root/src/Caddyfile
+              subPath: Caddyfile

--- a/tests/e2e/cachebust/04-assert.yaml
+++ b/tests/e2e/cachebust/04-assert.yaml
@@ -23,6 +23,13 @@ spec:
           configMap:
             name: test-cachebust-environment
             defaultMode: 420
+        - name: caddy
+          configMap:
+            name: test-cachebust-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
       containers:
         - name: fe-image
           image: quay.io/cloudservices/insights-chrome-frontend:a4ed168
@@ -37,6 +44,9 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: caddy
+              mountPath: /opt/app-root/src/Caddyfile
+              subPath: Caddyfile
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent
@@ -102,6 +112,13 @@ spec:
           configMap:
             name: test-cachebust-environment
             defaultMode: 420
+        - name: caddy
+          configMap:
+            name: test-cachebust-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
       containers:
         - name: fe-image
           image: quay.io/cloudservices/insights-chrome-frontend:a4ed168
@@ -116,6 +133,9 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: caddy
+              mountPath: /opt/app-root/src/Caddyfile
+              subPath: Caddyfile
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent
@@ -182,6 +202,13 @@ spec:
           configMap:
             name: test-cachebust-environment
             defaultMode: 420
+        - name: caddy
+          configMap:
+            name: test-cachebust-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
       containers:
         - name: fe-image
           image: quay.io/cloudservices/insights-chrome-frontend:a4ed168
@@ -196,3 +223,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: caddy
+              mountPath: /opt/app-root/src/Caddyfile
+              subPath: Caddyfile

--- a/tests/e2e/default-replicas/02-assert.yaml
+++ b/tests/e2e/default-replicas/02-assert.yaml
@@ -22,6 +22,13 @@ spec:
           configMap:
             name:  test-default-replicas-environment
             defaultMode: 420
+        - name: caddy
+          configMap:
+            name: test-default-replicas-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
       containers:
         - name: fe-image
           image: 'quay.io/cloudservices/insights-chrome-frontend:720317c'

--- a/tests/e2e/generate-bundles/02-assert.yaml
+++ b/tests/e2e/generate-bundles/02-assert.yaml
@@ -21,6 +21,13 @@ spec:
           configMap:
             name: test-generate-bundles-environment
             defaultMode: 420
+        - name: caddy
+          configMap:
+            name: test-generate-bundles-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
       containers:
         - name: fe-image
           image: quay.io/cloudservices/landing-page-frontend:3244a17
@@ -34,6 +41,9 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: caddy
+              mountPath: /opt/app-root/src/Caddyfile
+              subPath: Caddyfile
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/tests/e2e/generate-nav-json/02-assert.yaml
+++ b/tests/e2e/generate-nav-json/02-assert.yaml
@@ -21,6 +21,13 @@ spec:
           configMap:
             name: test-generate-nav-json-environment
             defaultMode: 420
+        - name: caddy
+          configMap:
+            name: test-generate-nav-json-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
       containers:
         - name: fe-image
           image: 'quay.io/cloudservices/insights-chrome-frontend:720317c'

--- a/tests/e2e/generate-search-index/02-assert.yaml
+++ b/tests/e2e/generate-search-index/02-assert.yaml
@@ -21,6 +21,13 @@ spec:
           configMap:
             name: test-search-index-environment
             defaultMode: 420
+        - name: caddy
+          configMap:
+            name: test-search-index-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
       containers:
         - name: fe-image
           image: quay.io/cloudservices/search-frontend:3244a17
@@ -34,6 +41,9 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: caddy
+              mountPath: /opt/app-root/src/Caddyfile
+              subPath: Caddyfile
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/tests/e2e/generate-service-tiles/02-assert.yaml
+++ b/tests/e2e/generate-service-tiles/02-assert.yaml
@@ -21,6 +21,13 @@ spec:
           configMap:
             name: test-service-tiles-environment
             defaultMode: 420
+        - name: caddy
+          configMap:
+            name: test-service-tiles-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
       containers:
         - name: fe-image
           image: quay.io/cloudservices/service-tiles-frontend:3244a17
@@ -34,6 +41,9 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: caddy
+              mountPath: /opt/app-root/src/Caddyfile
+              subPath: Caddyfile
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/tests/e2e/generate-widget-registry/02-assert.yaml
+++ b/tests/e2e/generate-widget-registry/02-assert.yaml
@@ -21,6 +21,13 @@ spec:
           configMap:
             name: test-widget-registry-environment
             defaultMode: 420
+        - name: caddy
+          configMap:
+            name: test-widget-registry-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
       containers:
         - name: fe-image
           image: quay.io/cloudservices/widgets-frontend:3244a17
@@ -34,6 +41,9 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: caddy
+              mountPath: /opt/app-root/src/Caddyfile
+              subPath: Caddyfile
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/tests/e2e/http_headers/02-assert.yaml
+++ b/tests/e2e/http_headers/02-assert.yaml
@@ -21,6 +21,13 @@ spec:
           configMap:
             name:  test-http-headers-environment
             defaultMode: 420
+        - name: caddy
+          configMap:
+            name: test-http-headers-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
       containers:
         - name: fe-image
           image: 'quay.io/cloudservices/insights-chrome-frontend:720317c'

--- a/tests/e2e/ingress-annotations/02-assert.yaml
+++ b/tests/e2e/ingress-annotations/02-assert.yaml
@@ -21,6 +21,13 @@ spec:
           configMap:
             name:  test-ingress-annotations-environment
             defaultMode: 420
+        - name: caddy
+          configMap:
+            name: test-ingress-annotations-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
       containers:
         - name: fe-image
           image: 'quay.io/cloudservices/insights-chrome-frontend:720317c'

--- a/tests/e2e/replicas/02-assert.yaml
+++ b/tests/e2e/replicas/02-assert.yaml
@@ -22,6 +22,13 @@ spec:
           configMap:
             name:  test-replicas-environment
             defaultMode: 420
+        - name: caddy
+          configMap:
+            name: test-replicas-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
       containers:
         - name: fe-image
           image: 'quay.io/cloudservices/insights-chrome-frontend:720317c'
@@ -35,6 +42,9 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: caddy
+              mountPath: /opt/app-root/src/Caddyfile
+              subPath: Caddyfile
 ---
 kind: Deployment
 apiVersion: apps/v1
@@ -59,6 +69,13 @@ spec:
           configMap:
             name:  test-replicas-environment
             defaultMode: 420
+        - name: caddy
+          configMap:
+            name: test-replicas-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
       containers:
         - name: fe-image
           image: 'quay.io/cloudservices/insights-chrome-frontend:720317c'
@@ -72,6 +89,9 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: caddy
+              mountPath: /opt/app-root/src/Caddyfile
+              subPath: Caddyfile
 ---
 kind: Deployment
 apiVersion: apps/v1
@@ -96,6 +116,13 @@ spec:
           configMap:
             name:  test-replicas-environment
             defaultMode: 420
+        - name: caddy
+          configMap:
+            name: test-replicas-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
       containers:
         - name: fe-image
           image: 'quay.io/cloudservices/insights-chrome-frontend:720317c'
@@ -109,3 +136,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: caddy
+              mountPath: /opt/app-root/src/Caddyfile
+              subPath: Caddyfile

--- a/tests/e2e/ssl/02-assert.yaml
+++ b/tests/e2e/ssl/02-assert.yaml
@@ -21,6 +21,13 @@ spec:
           configMap:
             name:  test-ssl-environment
             defaultMode: 420
+        - name: caddy
+          configMap:
+            name: test-ssl-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
         - name: certs
           secret:
             secretName: chrome-cert

--- a/tests/e2e/storage/02-assert.yaml
+++ b/tests/e2e/storage/02-assert.yaml
@@ -37,10 +37,17 @@ spec:
       securityContext: {}
       terminationGracePeriodSeconds: 30
       volumes:
-      - configMap:
-          defaultMode: 420
-          name: test-storage-environment
-        name: config
+        - configMap:
+            defaultMode: 420
+            name: test-storage-environment
+          name: config
+        - name: caddy
+          configMap:
+            name: test-storage-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/tests/e2e/whitelist/02-assert.yaml
+++ b/tests/e2e/whitelist/02-assert.yaml
@@ -21,6 +21,13 @@ spec:
           configMap:
             name:  test-whitelist-environment
             defaultMode: 420
+        - name: caddy
+          configMap:
+            name: test-whitelist-environment
+            defaultMode: 420
+            items:
+            - key: Caddyfile
+              path: Caddyfile
       containers:
         - name: fe-image
           image: 'quay.io/cloudservices/insights-chrome-frontend:720317c'


### PR DESCRIPTION
~This is really rough (no/broken tests; probably a better way to store the caddyfile in lieu of string,~ didn't remove or touch old logic etc).

However I do see this working locally. When I start up FEO I see the new pods come up with the new volume mount that override the Caddyfile.

*Edit* - updated to use go embed, added tests, and updated existing tests.