### PR TITLE
Annotate default configmap with "qontract.recycle"

### DIFF
--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -1258,7 +1258,7 @@ func (r *FrontendReconciliation) setupConfigMaps() (*v1.ConfigMap, error) {
 		})
 	}
 
-	defaultCfgMap, err := r.createConfigMap(defaultNN, frontendList, false)
+	defaultCfgMap, err := r.createConfigMap(defaultNN, frontendList, true)
 
 	for _, nn := range additionalNN {
 		_, err = r.createConfigMap(nn, frontendList, true)


### PR DESCRIPTION
This is needed for emphemeral environment to properly restart consumers of the config map.