### PR TITLE
Temporarily duplicate operator-generated volume mount to chrome.

### DIFF
--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -91,6 +91,7 @@ func (r *FrontendReconciliation) run() error {
 }
 
 func populateContainerVolumeMounts(frontendEnvironment *crd.FrontendEnvironment) []v1.VolumeMount {
+	// FIXME: Remove chrome specific exceptions once FEO generated assets are fully available and used in all envs
 
 	volumeMounts := []v1.VolumeMount{}
 
@@ -101,6 +102,12 @@ func populateContainerVolumeMounts(frontendEnvironment *crd.FrontendEnvironment)
 			Name:      "config",
 			MountPath: "/opt/app-root/src/build/chrome",
 		})
+		// We need to have duplicate entries for a while as we have a transition period
+		// In this transition we are "unchronifying" the chrome and making it a regular app with regular dir structure
+		volumeMounts = append(volumeMounts, v1.VolumeMount{
+			Name:      "config",
+			MountPath: "/srv/dist",
+		})
 	}
 
 	// We always want to mount the config map under the operator-generated directory
@@ -110,6 +117,13 @@ func populateContainerVolumeMounts(frontendEnvironment *crd.FrontendEnvironment)
 	volumeMounts = append(volumeMounts, v1.VolumeMount{
 		Name:      "config",
 		MountPath: "/opt/app-root/src/build/stable/operator-generated",
+	})
+
+	// We need to have duplicate entries for a while as we have a transition period
+	// In this transition we are "unchronifying" the chrome and making it a regular app with regular dir structure
+	volumeMounts = append(volumeMounts, v1.VolumeMount{
+		Name:      "config",
+		MountPath: "/srv/dist/operator-generated",
 	})
 
 	// We generate SSL cert mounts conditionally

--- a/tests/e2e/basic-frontend/02-assert.yaml
+++ b/tests/e2e/basic-frontend/02-assert.yaml
@@ -34,3 +34,5 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated

--- a/tests/e2e/bundles/02-assert.yaml
+++ b/tests/e2e/bundles/02-assert.yaml
@@ -35,7 +35,11 @@ spec:
             - name: config
               mountPath: /opt/app-root/src/build/chrome
             - name: config
+              mountPath: /srv/dist
+            - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
 ---
 apiVersion: cloud.redhat.com/v1alpha1
 kind: Bundle

--- a/tests/e2e/cachebust-multiple-urls/02-assert.yaml
+++ b/tests/e2e/cachebust-multiple-urls/02-assert.yaml
@@ -37,6 +37,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent
@@ -116,6 +118,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent
@@ -196,3 +200,5 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated

--- a/tests/e2e/cachebust/02-assert.yaml
+++ b/tests/e2e/cachebust/02-assert.yaml
@@ -37,6 +37,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent
@@ -116,6 +118,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent
@@ -196,3 +200,5 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated

--- a/tests/e2e/cachebust/04-assert.yaml
+++ b/tests/e2e/cachebust/04-assert.yaml
@@ -37,6 +37,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent
@@ -116,6 +118,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent
@@ -196,3 +200,5 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated

--- a/tests/e2e/default-replicas/02-assert.yaml
+++ b/tests/e2e/default-replicas/02-assert.yaml
@@ -35,3 +35,5 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated

--- a/tests/e2e/generate-bundles/02-assert.yaml
+++ b/tests/e2e/generate-bundles/02-assert.yaml
@@ -34,6 +34,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/tests/e2e/generate-nav-json/02-assert.yaml
+++ b/tests/e2e/generate-nav-json/02-assert.yaml
@@ -35,4 +35,8 @@ spec:
             - name: config
               mountPath: /opt/app-root/src/build/chrome
             - name: config
+              mountPath: /srv/dist
+            - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated

--- a/tests/e2e/generate-search-index/02-assert.yaml
+++ b/tests/e2e/generate-search-index/02-assert.yaml
@@ -34,6 +34,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/tests/e2e/generate-service-tiles/02-assert.yaml
+++ b/tests/e2e/generate-service-tiles/02-assert.yaml
@@ -34,6 +34,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/tests/e2e/generate-widget-registry/02-assert.yaml
+++ b/tests/e2e/generate-widget-registry/02-assert.yaml
@@ -34,6 +34,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/tests/e2e/http_headers/02-assert.yaml
+++ b/tests/e2e/http_headers/02-assert.yaml
@@ -44,3 +44,5 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated

--- a/tests/e2e/ingress-annotations/02-assert.yaml
+++ b/tests/e2e/ingress-annotations/02-assert.yaml
@@ -34,6 +34,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
 ---
 kind: Ingress
 apiVersion: networking.k8s.io/v1

--- a/tests/e2e/replicas/02-assert.yaml
+++ b/tests/e2e/replicas/02-assert.yaml
@@ -35,6 +35,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
 ---
 kind: Deployment
 apiVersion: apps/v1
@@ -72,6 +74,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
 ---
 kind: Deployment
 apiVersion: apps/v1
@@ -109,3 +113,5 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated

--- a/tests/e2e/ssl/02-assert.yaml
+++ b/tests/e2e/ssl/02-assert.yaml
@@ -43,5 +43,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
             - name: certs
               mountPath: /opt/certs

--- a/tests/e2e/storage/02-assert.yaml
+++ b/tests/e2e/storage/02-assert.yaml
@@ -34,6 +34,8 @@ spec:
         volumeMounts:
         - mountPath: /opt/app-root/src/build/stable/operator-generated
           name: config
+        - name: config
+          mountPath: /srv/dist/operator-generated
       securityContext: {}
       terminationGracePeriodSeconds: 30
       volumes:

--- a/tests/e2e/whitelist/02-assert.yaml
+++ b/tests/e2e/whitelist/02-assert.yaml
@@ -34,6 +34,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
 ---
 kind: Ingress
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
To remove all of the chrome-specific exceptions, we have to add some additional exceptions 😶 to ensure we have a migration window.

Currently, the operator-generated entry is used to source the SSO URL attribute, which is critical for proper auth flow. We will have to duplicate the volume mount to a new location. The location is based on the `build-tools` shared template for building the images: https://github.com/RedHatInsights/insights-frontend-builder-common/blob/596e85a62094b621345d9b0a057c39d12368b7a9/server_config_gen.sh#L41.

This is a future template that is being currently migrated to comply with Konflux EC hence we should use it for Chrome as well.

