### PR TITLE
Make requests and limits customizable per FrontendEnvironment

### DIFF
--- a/api/v1alpha1/frontendenvironment_types.go
+++ b/api/v1alpha1/frontendenvironment_types.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	errors "github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/errors"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -121,6 +122,9 @@ type FrontendEnvironmentSpec struct {
 	DefaultReplicas *int32 `json:"defaultReplicas,omitempty" yaml:"defaultReplicas,omitempty"`
 	// For the ChromeUI to render navigation bundles
 	Bundles *[]FrontendBundles `json:"bundles,omitempty" yaml:"bundles,omitempty"`
+
+	Requests *v1.ResourceList `json:"requests,omitempty" yaml:"requests,omitempty"`
+	Limits   *v1.ResourceList `json:"limits,omitempty" yaml:"limits,omitempty"`
 }
 
 type MonitoringConfig struct {

--- a/api/v1alpha1/frontendenvironment_types.go
+++ b/api/v1alpha1/frontendenvironment_types.go
@@ -123,8 +123,8 @@ type FrontendEnvironmentSpec struct {
 	// For the ChromeUI to render navigation bundles
 	Bundles *[]FrontendBundles `json:"bundles,omitempty" yaml:"bundles,omitempty"`
 
-	Requests *v1.ResourceList `json:"requests,omitempty" yaml:"requests,omitempty"`
-	Limits   *v1.ResourceList `json:"limits,omitempty" yaml:"limits,omitempty"`
+	Requests v1.ResourceList `json:"requests,omitempty" yaml:"requests,omitempty"`
+	Limits   v1.ResourceList `json:"limits,omitempty" yaml:"limits,omitempty"`
 }
 
 type MonitoringConfig struct {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -593,6 +594,20 @@ func (in *FrontendEnvironmentSpec) DeepCopyInto(out *FrontendEnvironmentSpec) {
 			in, out := *in, *out
 			*out = make([]FrontendBundles, len(*in))
 			copy(*out, *in)
+		}
+	}
+	if in.Requests != nil {
+		in, out := &in.Requests, &out.Requests
+		*out = make(corev1.ResourceList, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val.DeepCopy()
+		}
+	}
+	if in.Limits != nil {
+		in, out := &in.Limits, &out.Limits
+		*out = make(corev1.ResourceList, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val.DeepCopy()
 		}
 	}
 }

--- a/config/crd/bases/cloud.redhat.com_frontendenvironments.yaml
+++ b/config/crd/bases/cloud.redhat.com_frontendenvironments.yaml
@@ -115,6 +115,15 @@ spec:
               ingressClass:
                 description: Ingress class
                 type: string
+              limits:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: ResourceList is a set of (resource name, quantity) pairs.
+                type: object
               monitoring:
                 description: |-
                   MonitorMode determines where a ServiceMonitor object will be placed
@@ -131,6 +140,15 @@ spec:
                 required:
                 - disabled
                 - mode
+                type: object
+              requests:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: ResourceList is a set of (resource name, quantity) pairs.
                 type: object
               serviceCategories:
                 description: For the ChromeUI to render additional global components

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -138,6 +138,19 @@ func populateContainerVolumeMounts(frontendEnvironment *crd.FrontendEnvironment)
 }
 
 func populateContainer(d *apps.Deployment, frontend *crd.Frontend, frontendEnvironment *crd.FrontendEnvironment) {
+	cpuRequests := resource.MustParse("30m")
+	memoryRequests := resource.MustParse("50Mi")
+	cpuLimit := resource.MustParse("40m")
+	memoryLimit := resource.MustParse("100Mi")
+
+	if frontendEnvironment.Spec.Requests != nil {
+		cpuRequests = *frontendEnvironment.Spec.Requests.Cpu()
+		memoryRequests = *frontendEnvironment.Spec.Requests.Memory()
+	}
+	if frontendEnvironment.Spec.Limits != nil {
+		cpuLimit = *frontendEnvironment.Spec.Limits.Cpu()
+		memoryLimit = *frontendEnvironment.Spec.Limits.Memory()
+	}
 
 	// set the URI Scheme for the probe
 	probeScheme := v1.URISchemeHTTP
@@ -166,12 +179,12 @@ func populateContainer(d *apps.Deployment, frontend *crd.Frontend, frontendEnvir
 		VolumeMounts: populateContainerVolumeMounts(frontendEnvironment),
 		Resources: v1.ResourceRequirements{
 			Requests: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("30m"),
-				v1.ResourceMemory: resource.MustParse("50Mi"),
+				v1.ResourceCPU:    cpuRequests,
+				v1.ResourceMemory: memoryRequests,
 			},
 			Limits: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("40m"),
-				v1.ResourceMemory: resource.MustParse("150Mi"),
+				v1.ResourceCPU:    cpuLimit,
+				v1.ResourceMemory: memoryLimit,
 			},
 		},
 		LivenessProbe: &v1.Probe{

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -143,13 +143,13 @@ func populateContainer(d *apps.Deployment, frontend *crd.Frontend, frontendEnvir
 	cpuLimit := resource.MustParse("40m")
 	memoryLimit := resource.MustParse("100Mi")
 
-	if frontendEnvironment.Spec.Requests != nil {
-		cpuRequests = *frontendEnvironment.Spec.Requests.Cpu()
-		memoryRequests = *frontendEnvironment.Spec.Requests.Memory()
+	if len(frontendEnvironment.Spec.Requests) > 0 {
+		cpuRequests = frontendEnvironment.Spec.Requests[v1.ResourceCPU]
+		memoryRequests = frontendEnvironment.Spec.Requests[v1.ResourceMemory]
 	}
-	if frontendEnvironment.Spec.Limits != nil {
-		cpuLimit = *frontendEnvironment.Spec.Limits.Cpu()
-		memoryLimit = *frontendEnvironment.Spec.Limits.Memory()
+	if len(frontendEnvironment.Spec.Limits) > 0 {
+		cpuLimit = frontendEnvironment.Spec.Limits[v1.ResourceCPU]
+		memoryLimit = frontendEnvironment.Spec.Limits[v1.ResourceMemory]
 	}
 
 	// set the URI Scheme for the probe

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -138,7 +138,7 @@ func populateContainerVolumeMounts(frontendEnvironment *crd.FrontendEnvironment)
 }
 
 // GetResourceRequirements handles defaults and conditional overrides
-func GetResourceRequirements(spec *FrontendEnvironmentSpec) (resource.Quantity, resource.Quantity, resource.Quantity, resource.Quantity) {
+func GetResourceRequirements(frontendEnvironment *crd.FrontendEnvironment) (resource.Quantity, resource.Quantity, resource.Quantity, resource.Quantity) {
 	// Default values
 	cpuRequests := resource.MustParse("30m")
 	memoryRequests := resource.MustParse("50Mi")
@@ -146,21 +146,21 @@ func GetResourceRequirements(spec *FrontendEnvironmentSpec) (resource.Quantity, 
 	memoryLimit := resource.MustParse("100Mi")
 
 	// Handle Requests
-	if spec.Requests != nil {
-		if cpu, ok := spec.Requests[v1.ResourceCPU]; ok {
+	if frontendEnvironment.Spec.Requests != nil {
+		if cpu, ok := frontendEnvironment.Spec.Requests[v1.ResourceCPU]; ok {
 			cpuRequests = cpu
 		}
-		if memory, ok := spec.Requests[v1.ResourceMemory]; ok {
+		if memory, ok := frontendEnvironment.Spec.Requests[v1.ResourceMemory]; ok {
 			memoryRequests = memory
 		}
 	}
 
 	// Handle Limits
-	if spec.Limits != nil {
-		if cpu, ok := spec.Limits[v1.ResourceCPU]; ok {
+	if frontendEnvironment.Spec.Limits != nil {
+		if cpu, ok := frontendEnvironment.Spec.Limits[v1.ResourceCPU]; ok {
 			cpuLimit = cpu
 		}
-		if memory, ok := spec.Limits[v1.ResourceMemory]; ok {
+		if memory, ok := frontendEnvironment.Spec.Limits[v1.ResourceMemory]; ok {
 			memoryLimit = memory
 		}
 	}
@@ -170,7 +170,7 @@ func GetResourceRequirements(spec *FrontendEnvironmentSpec) (resource.Quantity, 
 
 func populateContainer(d *apps.Deployment, frontend *crd.Frontend, frontendEnvironment *crd.FrontendEnvironment) {
 	// Get the resource requirements
-	cpuRequests, memoryRequests, cpuLimit, memoryLimit := GetResourceRequirements(&frontendEnvironment.Spec)
+	cpuRequests, memoryRequests, cpuLimit, memoryLimit := GetResourceRequirements(frontendEnvironment)
 
 	// set the URI Scheme for the probe
 	probeScheme := v1.URISchemeHTTP

--- a/deploy.yml
+++ b/deploy.yml
@@ -356,6 +356,16 @@ objects:
                 ingressClass:
                   description: Ingress class
                   type: string
+                limits:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: ResourceList is a set of (resource name, quantity)
+                    pairs.
+                  type: object
                 monitoring:
                   description: 'MonitorMode determines where a ServiceMonitor object
                     will be placed
@@ -374,6 +384,16 @@ objects:
                   required:
                   - disabled
                   - mode
+                  type: object
+                requests:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: ResourceList is a set of (resource name, quantity)
+                    pairs.
                   type: object
                 serviceCategories:
                   description: For the ChromeUI to render additional global components

--- a/docs/antora/modules/ROOT/pages/api_reference.adoc
+++ b/docs/antora/modules/ROOT/pages/api_reference.adoc
@@ -184,6 +184,32 @@ _Underlying type:_ _string_
 
 
 
+[id="{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-bundlesegment"]
+==== BundleSegment
+
+
+
+
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-frontendspec[$$FrontendSpec$$]
+****
+
+[cols="20a,50a,15a,15a", options="header"]
+|===
+| Field | Description | Default | Validation
+| *`segmentId`* __string__ |  |  | 
+| *`bundleId`* __string__ | Id of the bundle to which the segment should be injected + |  | 
+| *`position`* __integer__ | A position of the segment within the bundle +
+0 is the first position +
+The position "steps" should be at least 100 to make sure there is enough space in case some segments should be injected between existing ones + |  | 
+| *`navItems`* __xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-chromenavitem[$$ChromeNavItem$$]__ |  |  | 
+|===
+
+
 [id="{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-bundlespec"]
 ==== BundleSpec
 
@@ -223,11 +249,13 @@ BundleSpec defines the desired state of Bundle
 
 .Appears In:
 ****
+- xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-bundlesegment[$$BundleSegment$$]
 - xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-bundlespec[$$BundleSpec$$]
 - xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-chromenavitem[$$ChromeNavItem$$]
 - xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-computedbundle[$$ComputedBundle$$]
 - xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-extranavitem[$$ExtraNavItem$$]
-- xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-navigationsegment[$$BundleSegment$$]
+- xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-frontendbundlesgenerated[$$FrontendBundlesGenerated$$]
+- xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-navigationsegment[$$NavigationSegment$$]
 ****
 
 [cols="20a,50a,15a,15a", options="header"]
@@ -250,6 +278,10 @@ BundleSpec defines the desired state of Bundle
 | *`routes`* __xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-chromenavitem[$$ChromeNavItem$$] array__ |  |  | Schemaless: {} +
 
 | *`permissions`* __xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-permission[$$Permission$$] array__ |  |  | 
+| *`position`* __integer__ | Position argument inherited from the segment, needed for smooth transition between old a new system and for proper developer experience + |  | 
+| *`segmentRef`* __xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-segmentref[$$SegmentRef$$]__ |  |  | 
+| *`bundleSegmentRef`* __string__ |  |  | 
+| *`frontendRef`* __string__ |  |  | 
 |===
 
 
@@ -354,6 +386,31 @@ Frontend is the Schema for the frontends API
  |  | 
 | *`spec`* __xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-frontendspec[$$FrontendSpec$$]__ |  |  | 
 |===
+
+
+[id="{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-frontendbundles"]
+==== FrontendBundles
+
+
+
+FrontendBundles defines the bundles specific to an environment that will be used to
+construct navigation
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-frontendenvironmentspec[$$FrontendEnvironmentSpec$$]
+****
+
+[cols="20a,50a,15a,15a", options="header"]
+|===
+| Field | Description | Default | Validation
+| *`id`* __string__ |  |  | 
+| *`title`* __string__ |  |  | 
+|===
+
+
 
 
 [id="{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-frontenddeployments"]
@@ -468,6 +525,9 @@ By configurations we mean the fed-modules.json, navigation files, etc. + |  |
 | *`httpHeaders`* __object (keys:string, values:string)__ | Custom HTTP Headers +
 These populate an ENV var that is then added into the caddy config as a header block + |  | 
 | *`defaultReplicas`* __integer__ |  |  | 
+| *`bundles`* __xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-frontendbundles[$$FrontendBundles$$]__ | For the ChromeUI to render navigation bundles + |  | 
+| *`requests`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#resourcelist-v1-core[$$ResourceList$$]__ |  |  | 
+| *`limits`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#resourcelist-v1-core[$$ResourceList$$]__ |  |  | 
 |===
 
 
@@ -615,7 +675,8 @@ FrontendSpec defines the desired state of Frontend
 | *`serviceMonitor`* __xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-servicemonitorconfig[$$ServiceMonitorConfig$$]__ |  |  | 
 | *`module`* __xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-fedmodule[$$FedModule$$]__ |  |  | 
 | *`navItems`* __xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-bundlenavitem[$$BundleNavItem$$] array__ |  |  | 
-| *`navigationSegments`* __xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-navigationsegment[$$BundleSegment$$] array__ | navigation segments for the frontend + |  | 
+| *`bundleSegments`* __xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-bundlesegment[$$BundleSegment$$] array__ | navigation segments for the frontend + |  | 
+| *`navigationSegments`* __xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-navigationsegment[$$NavigationSegment$$] array__ |  |  | 
 | *`assetsPrefix`* __string__ |  |  | 
 | *`akamaiCacheBustDisable`* __boolean__ | Akamai cache bust opt-out + |  | 
 | *`akamaiCacheBustPaths`* __string array__ | Files to cache bust + |  | 
@@ -731,7 +792,7 @@ FrontendSpec defines the desired state of Frontend
 
 
 [id="{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-navigationsegment"]
-==== BundleSegment
+==== NavigationSegment
 
 
 
@@ -747,11 +808,7 @@ FrontendSpec defines the desired state of Frontend
 [cols="20a,50a,15a,15a", options="header"]
 |===
 | Field | Description | Default | Validation
-| *`sectionId`* __string__ |  |  | 
-| *`bundleId`* __string__ | Id of the bundle to which the segment should be injected + |  | 
-| *`position`* __integer__ | A position of the segment within the bundle +
-0 is the first position +
-The position "steps" should be at least 100 to make sure there is enough space in case some segments should be injected between existing ones + |  | 
+| *`segmentId`* __string__ |  |  | 
 | *`navItems`* __xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-chromenavitem[$$ChromeNavItem$$]__ |  |  | 
 |===
 
@@ -769,6 +826,8 @@ _Underlying type:_ _xref:{anchor_prefix}-github-com-redhatinsights-frontend-oper
 ****
 - xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-chromenavitem[$$ChromeNavItem$$]
 - xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-route[$$Route$$]
+- xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-searchentry[$$SearchEntry$$]
+- xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-servicetile[$$ServiceTile$$]
 - xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-widgetconfig[$$WidgetConfig$$]
 ****
 
@@ -825,7 +884,25 @@ _Underlying type:_ _xref:{anchor_prefix}-github-com-redhatinsights-frontend-oper
 | *`description`* __string__ |  |  | 
 | *`alt_title`* __string array__ |  |  | 
 | *`isExternal`* __boolean__ |  |  | 
+| *`frontendRef`* __string__ |  |  | 
+| *`permissions`* __xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-permission[$$Permission$$] array__ |  |  | 
 |===
+
+
+[id="{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-segmentref"]
+==== SegmentRef
+
+_Underlying type:_ _xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-struct-frontendname string -json-frontendname- yaml-frontendname- segmentid string -json-segmentid- yaml-segmentid-[$$struct{FrontendName string "json:\"frontendName\" yaml:\"frontendName\""; SegmentID string "json:\"segmentId\" yaml:\"segmentId\""}$$]_
+
+
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-chromenavitem[$$ChromeNavItem$$]
+****
+
 
 
 [id="{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-servicemonitorconfig"]
@@ -875,6 +952,8 @@ _Underlying type:_ _xref:{anchor_prefix}-github-com-redhatinsights-frontend-oper
 | *`description`* __string__ |  |  | 
 | *`icon`* __string__ |  |  | 
 | *`isExternal`* __boolean__ |  |  | 
+| *`frontendRef`* __string__ |  |  | 
+| *`permissions`* __xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-permission[$$Permission$$] array__ |  |  | 
 |===
 
 
@@ -994,6 +1073,7 @@ _Underlying type:_ _xref:{anchor_prefix}-github-com-redhatinsights-frontend-oper
 | *`module`* __string__ |  |  | 
 | *`config`* __xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-widgetconfig[$$WidgetConfig$$]__ |  |  | 
 | *`defaults`* __xref:{anchor_prefix}-github-com-redhatinsights-frontend-operator-api-v1alpha1-widgetdefaults[$$WidgetDefaults$$]__ |  |  | 
+| *`frontendRef`* __string__ |  |  | 
 |===
 
 

--- a/tests/e2e/requests-and-limits/00-create-namespace.yaml
+++ b/tests/e2e/requests-and-limits/00-create-namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-basic-app
+spec:
+  finalizers:
+  - kubernetes

--- a/tests/e2e/requests-and-limits/01-create-resources.yaml
+++ b/tests/e2e/requests-and-limits/01-create-resources.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: FrontendEnvironment
+metadata:
+  name: test-basic-app-environment
+spec:
+  generateNavJSON: false
+  ssl: false
+  hostname: foo.redhat.com
+  sso: https://sso.foo.redhat.com
+  requests:
+    cpu: 25m
+    memory: 64Mi
+  limits:
+    cpu: 50m
+    memory: 128Mi
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: Frontend
+metadata:
+  name: chrome
+  namespace: test-basic-app
+spec:
+  API:
+    versions:
+      - v1
+  frontend:
+    paths:
+      - /
+  deploymentRepo: https://github.com/RedHatInsights/insights-chrome
+  envName: test-basic-app-environment
+  image: quay.io/cloudservices/insights-chrome-frontend:720317c
+  module:
+    config:
+      ssoUrl: 'https://'
+    manifestLocation: /apps/chrome/js/fed-mods.json
+  title: Chrome
+

--- a/tests/e2e/requests-and-limits/02-assert.yaml
+++ b/tests/e2e/requests-and-limits/02-assert.yaml
@@ -1,0 +1,45 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: chrome-frontend
+  namespace: test-basic-app
+  labels:
+    frontend: chrome
+  ownerReferences:
+    - apiVersion: cloud.redhat.com/v1alpha1
+      kind: Frontend
+      name: chrome
+spec:
+  selector:
+    matchLabels:
+      frontend: chrome
+  template:
+    spec:
+      volumes:
+        - name: config
+          configMap:
+            name:  test-basic-app-environment
+            defaultMode: 420
+      containers:
+        - name: fe-image
+          image: 'quay.io/cloudservices/insights-chrome-frontend:720317c'
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 50m
+              memory: 128Mi 
+          ports:
+            - name: web
+              containerPort: 80
+              protocol: TCP
+            - name: metrics
+              containerPort: 9000
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated


### PR DESCRIPTION
This patch extends the `FrontendEnvironment` to allow requests and limits to be set at the environment level. This allows us to have different resource usage in different environments, and makes changing the resources an at runtime change rather than a code change.