### PR TITLE
Revert "Temporarily duplicate operator-generated volume mount to chrome."

### DIFF
--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -91,7 +91,6 @@ func (r *FrontendReconciliation) run() error {
 }
 
 func populateContainerVolumeMounts(frontendEnvironment *crd.FrontendEnvironment) []v1.VolumeMount {
-	// FIXME: Remove chrome specific exceptions once FEO generated assets are fully available and used in all envs
 
 	volumeMounts := []v1.VolumeMount{}
 
@@ -102,12 +101,6 @@ func populateContainerVolumeMounts(frontendEnvironment *crd.FrontendEnvironment)
 			Name:      "config",
 			MountPath: "/opt/app-root/src/build/chrome",
 		})
-		// We need to have duplicate entries for a while as we have a transition period
-		// In this transition we are "unchronifying" the chrome and making it a regular app with regular dir structure
-		volumeMounts = append(volumeMounts, v1.VolumeMount{
-			Name:      "config",
-			MountPath: "/srv/dist",
-		})
 	}
 
 	// We always want to mount the config map under the operator-generated directory
@@ -117,13 +110,6 @@ func populateContainerVolumeMounts(frontendEnvironment *crd.FrontendEnvironment)
 	volumeMounts = append(volumeMounts, v1.VolumeMount{
 		Name:      "config",
 		MountPath: "/opt/app-root/src/build/stable/operator-generated",
-	})
-
-	// We need to have duplicate entries for a while as we have a transition period
-	// In this transition we are "unchronifying" the chrome and making it a regular app with regular dir structure
-	volumeMounts = append(volumeMounts, v1.VolumeMount{
-		Name:      "config",
-		MountPath: "/srv/dist/operator-generated",
 	})
 
 	// We generate SSL cert mounts conditionally

--- a/tests/e2e/basic-frontend/02-assert.yaml
+++ b/tests/e2e/basic-frontend/02-assert.yaml
@@ -34,5 +34,3 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
-            - name: config
-              mountPath: /srv/dist/operator-generated

--- a/tests/e2e/bundles/02-assert.yaml
+++ b/tests/e2e/bundles/02-assert.yaml
@@ -35,11 +35,7 @@ spec:
             - name: config
               mountPath: /opt/app-root/src/build/chrome
             - name: config
-              mountPath: /srv/dist
-            - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
-            - name: config
-              mountPath: /srv/dist/operator-generated
 ---
 apiVersion: cloud.redhat.com/v1alpha1
 kind: Bundle

--- a/tests/e2e/cachebust-multiple-urls/02-assert.yaml
+++ b/tests/e2e/cachebust-multiple-urls/02-assert.yaml
@@ -37,8 +37,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
-            - name: config
-              mountPath: /srv/dist/operator-generated
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent
@@ -118,8 +116,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
-            - name: config
-              mountPath: /srv/dist/operator-generated
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent
@@ -200,5 +196,3 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
-            - name: config
-              mountPath: /srv/dist/operator-generated

--- a/tests/e2e/cachebust/02-assert.yaml
+++ b/tests/e2e/cachebust/02-assert.yaml
@@ -37,8 +37,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
-            - name: config
-              mountPath: /srv/dist/operator-generated
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent
@@ -118,8 +116,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
-            - name: config
-              mountPath: /srv/dist/operator-generated
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent
@@ -200,5 +196,3 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
-            - name: config
-              mountPath: /srv/dist/operator-generated

--- a/tests/e2e/cachebust/04-assert.yaml
+++ b/tests/e2e/cachebust/04-assert.yaml
@@ -37,8 +37,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
-            - name: config
-              mountPath: /srv/dist/operator-generated
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent
@@ -118,8 +116,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
-            - name: config
-              mountPath: /srv/dist/operator-generated
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent
@@ -200,5 +196,3 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
-            - name: config
-              mountPath: /srv/dist/operator-generated

--- a/tests/e2e/default-replicas/02-assert.yaml
+++ b/tests/e2e/default-replicas/02-assert.yaml
@@ -35,5 +35,3 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
-            - name: config
-              mountPath: /srv/dist/operator-generated

--- a/tests/e2e/generate-bundles/02-assert.yaml
+++ b/tests/e2e/generate-bundles/02-assert.yaml
@@ -34,8 +34,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
-            - name: config
-              mountPath: /srv/dist/operator-generated
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/tests/e2e/generate-nav-json/02-assert.yaml
+++ b/tests/e2e/generate-nav-json/02-assert.yaml
@@ -35,8 +35,4 @@ spec:
             - name: config
               mountPath: /opt/app-root/src/build/chrome
             - name: config
-              mountPath: /srv/dist
-            - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
-            - name: config
-              mountPath: /srv/dist/operator-generated

--- a/tests/e2e/generate-search-index/02-assert.yaml
+++ b/tests/e2e/generate-search-index/02-assert.yaml
@@ -34,8 +34,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
-            - name: config
-              mountPath: /srv/dist/operator-generated
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/tests/e2e/generate-service-tiles/02-assert.yaml
+++ b/tests/e2e/generate-service-tiles/02-assert.yaml
@@ -34,8 +34,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
-            - name: config
-              mountPath: /srv/dist/operator-generated
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/tests/e2e/generate-widget-registry/02-assert.yaml
+++ b/tests/e2e/generate-widget-registry/02-assert.yaml
@@ -34,8 +34,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
-            - name: config
-              mountPath: /srv/dist/operator-generated
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/tests/e2e/http_headers/02-assert.yaml
+++ b/tests/e2e/http_headers/02-assert.yaml
@@ -44,5 +44,3 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
-            - name: config
-              mountPath: /srv/dist/operator-generated

--- a/tests/e2e/ingress-annotations/02-assert.yaml
+++ b/tests/e2e/ingress-annotations/02-assert.yaml
@@ -34,8 +34,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
-            - name: config
-              mountPath: /srv/dist/operator-generated
 ---
 kind: Ingress
 apiVersion: networking.k8s.io/v1

--- a/tests/e2e/replicas/02-assert.yaml
+++ b/tests/e2e/replicas/02-assert.yaml
@@ -35,8 +35,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
-            - name: config
-              mountPath: /srv/dist/operator-generated
 ---
 kind: Deployment
 apiVersion: apps/v1
@@ -74,8 +72,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
-            - name: config
-              mountPath: /srv/dist/operator-generated
 ---
 kind: Deployment
 apiVersion: apps/v1
@@ -113,5 +109,3 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
-            - name: config
-              mountPath: /srv/dist/operator-generated

--- a/tests/e2e/ssl/02-assert.yaml
+++ b/tests/e2e/ssl/02-assert.yaml
@@ -43,7 +43,5 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
-            - name: config
-              mountPath: /srv/dist/operator-generated
             - name: certs
               mountPath: /opt/certs

--- a/tests/e2e/storage/02-assert.yaml
+++ b/tests/e2e/storage/02-assert.yaml
@@ -34,8 +34,6 @@ spec:
         volumeMounts:
         - mountPath: /opt/app-root/src/build/stable/operator-generated
           name: config
-        - name: config
-          mountPath: /srv/dist/operator-generated
       securityContext: {}
       terminationGracePeriodSeconds: 30
       volumes:

--- a/tests/e2e/whitelist/02-assert.yaml
+++ b/tests/e2e/whitelist/02-assert.yaml
@@ -34,8 +34,6 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
-            - name: config
-              mountPath: /srv/dist/operator-generated
 ---
 kind: Ingress
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
Reverts RedHatInsights/frontend-operator#256

There are issues with the additional volume, we will need slight adjustment to the mount, but I won't. have time this week. We should roll back to changes to prevent regressions in stage.