### PR TITLE
Fix malformed caddyfile

### DIFF
--- a/api/v1alpha1/frontendenvironment_types.go
+++ b/api/v1alpha1/frontendenvironment_types.go
@@ -118,6 +118,9 @@ type FrontendEnvironmentSpec struct {
 	// Custom HTTP Headers
 	// These populate an ENV var that is then added into the caddy config as a header block
 	HTTPHeaders map[string]string `json:"httpHeaders,omitempty"`
+	// OverwriteCaddyConfig determines if the operator should overwrite
+	// frontend container Caddyfiles with a common core Caddyfile
+	OverwriteCaddyConfig bool `json:"overwriteCaddyConfig,omitempty"`
 
 	DefaultReplicas *int32 `json:"defaultReplicas,omitempty" yaml:"defaultReplicas,omitempty"`
 	// For the ChromeUI to render navigation bundles

--- a/config/crd/bases/cloud.redhat.com_frontendenvironments.yaml
+++ b/config/crd/bases/cloud.redhat.com_frontendenvironments.yaml
@@ -141,6 +141,11 @@ spec:
                 - disabled
                 - mode
                 type: object
+              overwriteCaddyConfig:
+                description: |-
+                  OverwriteCaddyConfig determines if the operator should overwrite
+                  frontend container Caddyfiles with a common core Caddyfile
+                type: boolean
               requests:
                 additionalProperties:
                   anyOf:

--- a/controllers/frontend_controller_suite_test.go
+++ b/controllers/frontend_controller_suite_test.go
@@ -148,7 +148,8 @@ var _ = ginkgo.Describe("Frontend controller with image", func() {
 					Monitoring: &crd.MonitoringConfig{
 						Mode: "app-interface",
 					},
-					GenerateNavJSON: true,
+					GenerateNavJSON:      true,
+					OverwriteCaddyConfig: true,
 				},
 			}
 			gomega.Expect(k8sClient.Create(ctx, frontendEnvironment)).Should(gomega.Succeed())

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -116,7 +116,7 @@ func populateContainerVolumeMounts(frontendEnvironment *crd.FrontendEnvironment,
 		MountPath: "/opt/app-root/src/build/stable/operator-generated",
 	})
 
-	if frontend.Name != "chrome" {
+	if frontendEnvironment.Spec.OverwriteCaddyConfig && frontend.Name != "chrome" {
 		volumeMounts = append(volumeMounts, v1.VolumeMount{
 			Name:      "caddy",
 			MountPath: "/opt/app-root/src/Caddyfile",

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -479,6 +479,26 @@ func (r *FrontendReconciliation) populateEnvVars(d *apps.Deployment, frontendEnv
 		})
 	}
 
+	envVars = append(envVars, v1.EnvVar{
+		Name:  "APP_NAME",
+		Value: r.Frontend.Name,
+	})
+
+	envVars = append(envVars, v1.EnvVar{
+		Name:  "ROUTE_PATH",
+		Value: "/apps/$(APP_NAME)",
+	})
+
+	envVars = append(envVars, v1.EnvVar{
+		Name:  "BETA_ROUTE_PATH",
+		Value: "/beta$(ROUTE_PATH)",
+	})
+
+	envVars = append(envVars, v1.EnvVar{
+		Name:  "PREVIEW_ROUTE_PATH",
+		Value: "/preview$(ROUTE_PATH)",
+	})
+
 	d.Spec.Template.Spec.Containers[0].Env = envVars
 }
 

--- a/controllers/templates/Caddyfile
+++ b/controllers/templates/Caddyfile
@@ -2,7 +2,7 @@
     {$CADDY_TLS_MODE}
     auto_https disable_redirects
     servers {
-        metrics
+      metrics
     }
 }
 
@@ -17,14 +17,46 @@
 
     # Handle main app route
     @app_match {
-        path ${ROUTE_PATH}*
+        path {$ROUTE_PATH}*
     }
     handle @app_match {
-        uri strip_prefix ${ROUTE_PATH}
+        uri strip_prefix {$ROUTE_PATH}
         file_server * {
-            root /srv/${OUTPUT_DIR}
+            root /opt/app-root/src/dist/stable
             browse
         }
+    }
+
+    # Handle beta app route
+    @beta_match {
+        path {$BETA_ROUTE_PATH}*
+    }
+    handle @beta_match {
+        uri strip_prefix {$BETA_ROUTE_PATH}
+        file_server * {
+            root /opt/app-root/src/dist/preview
+            browse
+        }
+    }
+
+    # Handle preview app route
+    @preview_match {
+        path {$PREVIEW_ROUTE_PATH}*
+    }
+    handle @preview_match {
+        uri strip_prefix {$PREVIEW_ROUTE_PATH}
+        file_server * {
+            root /opt/app-root/src/dist/preview
+            browse
+        }
+    }
+
+    handle /beta/ {
+        redir /beta/apps/chrome/index.html permanent
+    }
+
+    handle /preview/ {
+        redir /preview/apps/chrome/index.html permanent
     }
 
     handle / {

--- a/deploy.yml
+++ b/deploy.yml
@@ -385,6 +385,12 @@ objects:
                   - disabled
                   - mode
                   type: object
+                overwriteCaddyConfig:
+                  description: 'OverwriteCaddyConfig determines if the operator should
+                    overwrite
+
+                    frontend container Caddyfiles with a common core Caddyfile'
+                  type: boolean
                 requests:
                   additionalProperties:
                     anyOf:

--- a/tests/e2e/bundles/01-create-resources.yaml
+++ b/tests/e2e/bundles/01-create-resources.yaml
@@ -8,6 +8,7 @@ spec:
   ssl: false
   hostname: foo.redhat.com
   sso: https://sso.foo.redhat.com
+  overwriteCaddyConfig: true
 ---
 apiVersion: cloud.redhat.com/v1alpha1
 kind: Frontend

--- a/tests/e2e/cachebust-multiple-urls/01-create-resources.yaml
+++ b/tests/e2e/cachebust-multiple-urls/01-create-resources.yaml
@@ -8,6 +8,7 @@ spec:
   ssl: false
   hostname: foo.redhat.com
   sso: https://sso.foo.redhat.com
+  overwriteCaddyConfig: true
   enableAkamaiCacheBust: true
   akamaiCacheBustImage: "quay.io/rh_ee_addrew/hi_true_bye:add_alias"
   akamaiCacheBustURLs: 

--- a/tests/e2e/cachebust/01-create-resources.yaml
+++ b/tests/e2e/cachebust/01-create-resources.yaml
@@ -8,6 +8,7 @@ spec:
   ssl: false
   hostname: foo.redhat.com
   sso: https://sso.foo.redhat.com
+  overwriteCaddyConfig: true
   enableAkamaiCacheBust: true
   akamaiCacheBustImage: "quay.io/rh_ee_addrew/hi_true_bye:add_alias"
   akamaiCacheBustURL: "console.doesntexist.redhat.com"

--- a/tests/e2e/generate-bundles/01-create-resources.yaml
+++ b/tests/e2e/generate-bundles/01-create-resources.yaml
@@ -8,6 +8,7 @@ spec:
   ssl: false
   hostname: foo.redhat.com
   sso: https://sso.foo.redhat.com
+  overwriteCaddyConfig: true
   bundles:
    - id: rhel
      title: Red Hat Enterprise Linux

--- a/tests/e2e/generate-search-index/01-create-resources.yaml
+++ b/tests/e2e/generate-search-index/01-create-resources.yaml
@@ -8,6 +8,7 @@ spec:
   ssl: false
   hostname: foo.redhat.com
   sso: https://sso.foo.redhat.com
+  overwriteCaddyConfig: true
 ---
 apiVersion: cloud.redhat.com/v1alpha1
 kind: Frontend

--- a/tests/e2e/generate-service-tiles/01-create-resources.yaml
+++ b/tests/e2e/generate-service-tiles/01-create-resources.yaml
@@ -8,6 +8,7 @@ spec:
   ssl: false
   hostname: foo.redhat.com
   sso: https://sso.foo.redhat.com
+  overwriteCaddyConfig: true
   serviceCategories:
     - id: automation
       title: Automation

--- a/tests/e2e/generate-widget-registry/01-create-resources.yaml
+++ b/tests/e2e/generate-widget-registry/01-create-resources.yaml
@@ -8,6 +8,7 @@ spec:
   ssl: false
   hostname: foo.redhat.com
   sso: https://sso.foo.redhat.com
+  overwriteCaddyConfig: true
 ---
 apiVersion: cloud.redhat.com/v1alpha1
 kind: Frontend

--- a/tests/e2e/http_headers/02-assert.yaml
+++ b/tests/e2e/http_headers/02-assert.yaml
@@ -41,6 +41,14 @@ spec:
                 X-Frame-Options Set
                 X-XSS-Protection 1; mode=block;
                 }
+            - name: APP_NAME
+              value: chrome
+            - name: ROUTE_PATH
+              value: /apps/$(APP_NAME)
+            - name: BETA_ROUTE_PATH
+              value: /beta$(ROUTE_PATH)
+            - name: PREVIEW_ROUTE_PATH
+              value: /preview$(ROUTE_PATH)
           ports:
             - name: web
               containerPort: 80

--- a/tests/e2e/replicas/01-create-resources.yaml
+++ b/tests/e2e/replicas/01-create-resources.yaml
@@ -8,6 +8,7 @@ spec:
   ssl: false
   hostname: foo.redhat.com
   sso: https://sso.foo.redhat.com
+  overwriteCaddyConfig: true
 ---
 apiVersion: cloud.redhat.com/v1alpha1
 kind: Frontend

--- a/tests/e2e/ssl/02-assert.yaml
+++ b/tests/e2e/ssl/02-assert.yaml
@@ -47,6 +47,14 @@ spec:
               value: https_port 8000
             - name: CADDY_TLS_CERT
               value: tls /opt/certs/tls.crt /opt/certs/tls.key
+            - name: APP_NAME
+              value: chrome
+            - name: ROUTE_PATH
+              value: /apps/$(APP_NAME)
+            - name: BETA_ROUTE_PATH
+              value: /beta$(ROUTE_PATH)
+            - name: PREVIEW_ROUTE_PATH
+              value: /preview$(ROUTE_PATH)
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated


### PR DESCRIPTION
Rolling the latest FEO out to stage broke stage. Several apps returning 200;s but with empty content for "fed-mods.json" and all other files.  I originally thought the Caddyfile previously delivered worked locally - however Caddy defaults to returning 200's if there is no route "configured" and simply logs `noop` in the pod logs.

We discovered frontends using Konflux are using task `create-frontend-dockerfile` which creates the Caddyfile: https://github.com/RedHatInsights/konflux-consoledot-frontend-build/blob/main/tasks/create-frontend-dockerfile/create-frontend-dockerfile.yaml#L74. Note this references `frontend-build-container:3bacc0b`

`frontend-build-container:3bacc0b` Caddyfile can be found here:
https://gitlab.cee.redhat.com/insights-platform/frontend-build-container/-/blob/3bacc0b6ae373b84bdc30adf06c4ac32dd82d024/server_config_gen.sh#L22

I've updated our Caddyfile to match what is in `frontend-build-container:3bacc0b` as closely as possible.