### PR TITLE
Mount operator-generated dir into submodule build container assets.

### DIFF
--- a/controllers/frontend_controller_suite_test.go
+++ b/controllers/frontend_controller_suite_test.go
@@ -192,6 +192,14 @@ var _ = ginkgo.Describe("Frontend controller with image", func() {
 					MountPath: "/opt/app-root/src/build/stable/operator-generated",
 				},
 				{
+					Name:             "config",
+					ReadOnly:         false,
+					MountPath:        "/srv/dist/operator-generated",
+					SubPath:          "operator-generated",
+					MountPropagation: nil,
+					SubPathExpr:      "",
+				},
+				{
 					Name:      "caddy",
 					MountPath: "/opt/app-root/src/Caddyfile",
 					SubPath:   "Caddyfile",
@@ -598,6 +606,14 @@ var _ = ginkgo.Describe("Frontend controller with chrome", func() {
 				{
 					Name:      "config",
 					MountPath: "/opt/app-root/src/build/stable/operator-generated",
+				},
+				{
+					Name:             "config",
+					ReadOnly:         false,
+					MountPath:        "/srv/dist/operator-generated",
+					SubPath:          "operator-generated",
+					MountPropagation: nil,
+					SubPathExpr:      "",
 				},
 			}
 			gomega.Expect(createdDeployment.Name).Should(gomega.Equal(FrontendName + "-frontend"))

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -116,6 +116,15 @@ func populateContainerVolumeMounts(frontendEnvironment *crd.FrontendEnvironment,
 		MountPath: "/opt/app-root/src/build/stable/operator-generated",
 	})
 
+	// FIXME: Remove chrome specific exceptions once FEO generated assets are fully available and used in all envs
+	// We need to have duplicate entries for a while as we have a transition period
+	// In this transition we are "unchronifying" the chrome and making it a regular app with regular dir structure
+	volumeMounts = append(volumeMounts, v1.VolumeMount{
+		Name:      "config",
+		MountPath: "/srv/dist/operator-generated",
+		SubPath:   "operator-generated",
+	})
+
 	if frontendEnvironment.Spec.OverwriteCaddyConfig && frontend.Name != "chrome" {
 		volumeMounts = append(volumeMounts, v1.VolumeMount{
 			Name:      "caddy",

--- a/kuttl-config.yml
+++ b/kuttl-config.yml
@@ -5,7 +5,7 @@ startControlPlane: true
 crdDir: config/crd/test-resources/
 testDirs:
 - tests/e2e/
-timeout: 320
+timeout: 20
 parallel: 1
 commands:
 - command: make install

--- a/tests/e2e/basic-frontend/02-assert.yaml
+++ b/tests/e2e/basic-frontend/02-assert.yaml
@@ -41,3 +41,5 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated

--- a/tests/e2e/bundles/02-assert.yaml
+++ b/tests/e2e/bundles/02-assert.yaml
@@ -43,6 +43,8 @@ spec:
               mountPath: /opt/app-root/src/build/chrome
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
             - name: caddy
               mountPath: /opt/app-root/src/Caddyfile
               subPath: Caddyfile

--- a/tests/e2e/cachebust-multiple-urls/02-assert.yaml
+++ b/tests/e2e/cachebust-multiple-urls/02-assert.yaml
@@ -44,6 +44,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
             - name: caddy
               mountPath: /opt/app-root/src/Caddyfile
               subPath: Caddyfile
@@ -132,7 +134,9 @@ spec:
           resources: {}
           volumeMounts:
             - name: config
-              mountPath: /opt/app-root/src/build/stable/operator-generated
+              mountPath: /opt/app-root/src/build/stable/operator-generated 
+            - name: config
+              mountPath: /srv/dist/operator-generated
             - name: caddy
               mountPath: /opt/app-root/src/Caddyfile
               subPath: Caddyfile
@@ -222,7 +226,9 @@ spec:
           resources: {}
           volumeMounts:
             - name: config
-              mountPath: /opt/app-root/src/build/stable/operator-generated
+              mountPath: /opt/app-root/src/build/stable/operator-generated 
+            - name: config
+              mountPath: /srv/dist/operator-generated
             - name: caddy
               mountPath: /opt/app-root/src/Caddyfile
               subPath: Caddyfile

--- a/tests/e2e/cachebust/02-assert.yaml
+++ b/tests/e2e/cachebust/02-assert.yaml
@@ -44,6 +44,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
             - name: caddy
               mountPath: /opt/app-root/src/Caddyfile
               subPath: Caddyfile
@@ -132,7 +134,9 @@ spec:
           resources: {}
           volumeMounts:
             - name: config
-              mountPath: /opt/app-root/src/build/stable/operator-generated
+              mountPath: /opt/app-root/src/build/stable/operator-generated 
+            - name: config
+              mountPath: /srv/dist/operator-generated
             - name: caddy
               mountPath: /opt/app-root/src/Caddyfile
               subPath: Caddyfile
@@ -222,7 +226,9 @@ spec:
           resources: {}
           volumeMounts:
             - name: config
-              mountPath: /opt/app-root/src/build/stable/operator-generated
+              mountPath: /opt/app-root/src/build/stable/operator-generated 
+            - name: config
+              mountPath: /srv/dist/operator-generated
             - name: caddy
               mountPath: /opt/app-root/src/Caddyfile
               subPath: Caddyfile

--- a/tests/e2e/cachebust/04-assert.yaml
+++ b/tests/e2e/cachebust/04-assert.yaml
@@ -44,6 +44,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
             - name: caddy
               mountPath: /opt/app-root/src/Caddyfile
               subPath: Caddyfile
@@ -132,7 +134,9 @@ spec:
           resources: {}
           volumeMounts:
             - name: config
-              mountPath: /opt/app-root/src/build/stable/operator-generated
+              mountPath: /opt/app-root/src/build/stable/operator-generated 
+            - name: config
+              mountPath: /srv/dist/operator-generated
             - name: caddy
               mountPath: /opt/app-root/src/Caddyfile
               subPath: Caddyfile
@@ -222,7 +226,9 @@ spec:
           resources: {}
           volumeMounts:
             - name: config
-              mountPath: /opt/app-root/src/build/stable/operator-generated
+              mountPath: /opt/app-root/src/build/stable/operator-generated 
+            - name: config
+              mountPath: /srv/dist/operator-generated
             - name: caddy
               mountPath: /opt/app-root/src/Caddyfile
               subPath: Caddyfile

--- a/tests/e2e/default-replicas/02-assert.yaml
+++ b/tests/e2e/default-replicas/02-assert.yaml
@@ -42,3 +42,5 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated

--- a/tests/e2e/generate-bundles/02-assert.yaml
+++ b/tests/e2e/generate-bundles/02-assert.yaml
@@ -41,6 +41,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
             - name: caddy
               mountPath: /opt/app-root/src/Caddyfile
               subPath: Caddyfile

--- a/tests/e2e/generate-nav-json/02-assert.yaml
+++ b/tests/e2e/generate-nav-json/02-assert.yaml
@@ -43,3 +43,5 @@ spec:
               mountPath: /opt/app-root/src/build/chrome
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated

--- a/tests/e2e/generate-search-index/02-assert.yaml
+++ b/tests/e2e/generate-search-index/02-assert.yaml
@@ -41,6 +41,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
             - name: caddy
               mountPath: /opt/app-root/src/Caddyfile
               subPath: Caddyfile

--- a/tests/e2e/generate-service-tiles/02-assert.yaml
+++ b/tests/e2e/generate-service-tiles/02-assert.yaml
@@ -41,6 +41,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
             - name: caddy
               mountPath: /opt/app-root/src/Caddyfile
               subPath: Caddyfile

--- a/tests/e2e/generate-widget-registry/02-assert.yaml
+++ b/tests/e2e/generate-widget-registry/02-assert.yaml
@@ -41,6 +41,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
             - name: caddy
               mountPath: /opt/app-root/src/Caddyfile
               subPath: Caddyfile

--- a/tests/e2e/http_headers/02-assert.yaml
+++ b/tests/e2e/http_headers/02-assert.yaml
@@ -59,3 +59,5 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated

--- a/tests/e2e/ingress-annotations/02-assert.yaml
+++ b/tests/e2e/ingress-annotations/02-assert.yaml
@@ -41,6 +41,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
 ---
 kind: Ingress
 apiVersion: networking.k8s.io/v1

--- a/tests/e2e/replicas/02-assert.yaml
+++ b/tests/e2e/replicas/02-assert.yaml
@@ -42,6 +42,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
             - name: caddy
               mountPath: /opt/app-root/src/Caddyfile
               subPath: Caddyfile
@@ -88,7 +90,9 @@ spec:
               protocol: TCP
           volumeMounts:
             - name: config
-              mountPath: /opt/app-root/src/build/stable/operator-generated
+              mountPath: /opt/app-root/src/build/stable/operator-generated 
+            - name: config
+              mountPath: /srv/dist/operator-generated
             - name: caddy
               mountPath: /opt/app-root/src/Caddyfile
               subPath: Caddyfile
@@ -135,7 +139,9 @@ spec:
               protocol: TCP
           volumeMounts:
             - name: config
-              mountPath: /opt/app-root/src/build/stable/operator-generated
+              mountPath: /opt/app-root/src/build/stable/operator-generated 
+            - name: config
+              mountPath: /srv/dist/operator-generated
             - name: caddy
               mountPath: /opt/app-root/src/Caddyfile
               subPath: Caddyfile

--- a/tests/e2e/requests-and-limits/02-assert.yaml
+++ b/tests/e2e/requests-and-limits/02-assert.yaml
@@ -48,3 +48,5 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated

--- a/tests/e2e/ssl/02-assert.yaml
+++ b/tests/e2e/ssl/02-assert.yaml
@@ -58,5 +58,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
             - name: certs
               mountPath: /opt/certs

--- a/tests/e2e/storage/02-assert.yaml
+++ b/tests/e2e/storage/02-assert.yaml
@@ -34,6 +34,8 @@ spec:
         volumeMounts:
         - mountPath: /opt/app-root/src/build/stable/operator-generated
           name: config
+        - name: config
+          mountPath: /srv/dist/operator-generated
       securityContext: {}
       terminationGracePeriodSeconds: 30
       volumes:

--- a/tests/e2e/whitelist/02-assert.yaml
+++ b/tests/e2e/whitelist/02-assert.yaml
@@ -41,6 +41,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /opt/app-root/src/build/stable/operator-generated
+            - name: config
+              mountPath: /srv/dist/operator-generated
 ---
 kind: Ingress
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
This should not override the asset dir. We only need the operator generated assets.