### PR TITLE
[All PRs] Fix upstream lint job failures

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,6 +38,7 @@ issues:
   # Set to 0 to disable.
   # Default: 3
   max-same-issues: 20
+  uniq-by-line: false
 
 output:
 # The formats used to render issues.
@@ -76,7 +77,6 @@ output:
   sort-results: true
 # Make issues output unique by line.
 # Default: true
-  uniq-by-line: false
 
 run:
   # Timeout for analysis, e.g. 30s, 5m.


### PR DESCRIPTION
Seems like our config is no longer valid. This error is now on all PRs:
```bash
run golangci-lint
Error: Failed to run: Error: Command failed: /home/runner/golangci-lint-1.64.5-linux-amd64/golangci-lint config verify
jsonschema: "output" does not validate with "/properties/output/additionalProperties": additional properties 'uniq-by-line' not allowed
Failed executing command with error: the configuration contains invalid elements
, Error: Command failed: /home/runner/golangci-lint-1.64.5-linux-amd64/golangci-lint config verify
jsonschema: "output" does not validate with "/properties/output/additionalProperties": additional properties 'uniq-by-line' not allowed
Failed executing command with error: the configuration contains invalid elements

    at genericNodeError (node:internal/errors:984:15)
    at wrappedFn (node:internal/errors:5[38](https://github.com/RedHatInsights/frontend-operator/actions/runs/13400403986/job/37429623604?pr=267#step:5:41):14)
    at ChildProcess.exithandler (node:child_process:422:12)
    at ChildProcess.emit (node:events:519:28)
    at maybeClose (node:internal/child_process:1105:16)
    at ChildProcess._handle.onexit (node:internal/child_process:305:5)
Error: Command failed: /home/runner/golangci-lint-1.64.5-linux-amd64/golangci-lint config verify
jsonschema: "output" does not validate with "/properties/output/additionalProperties": additional properties 'uniq-by-line' not allowed
Failed executing command with error: the configuration contains invalid elements
```

This fix seems to resolve the issue.