### PR TITLE
Fix search index sorting condition.

### DIFF
--- a/controllers/frontend_controller_suite_test.go
+++ b/controllers/frontend_controller_suite_test.go
@@ -1071,15 +1071,15 @@ var _ = ginkgo.Describe("Search index", func() {
 					SearchFrontendEntries: []SearchFrontendEntry{{
 						Name: FrontendName,
 						SearchEntries: []*crd.SearchEntry{{
-							ID:          "test",
-							Href:        "/test/href",
-							Title:       "Test",
-							Description: "Test description",
-						}, {
 							ID:          "test2",
 							Href:        "/test2/href",
 							Title:       "Test2",
 							Description: "Test2 description",
+						}, {
+							ID:          "test",
+							Href:        "/test/href",
+							Title:       "Test",
+							Description: "Test description",
 						}},
 					}},
 				}

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -1031,7 +1031,9 @@ func setupSearchIndex(feList *crd.FrontendList) []crd.SearchEntry {
 
 	// Sort searchIndex alphabetically
 	sort.Slice(searchIndex, func(i, j int) bool {
-		return searchIndex[i].Title < searchIndex[j].Title && searchIndex[i].Description < searchIndex[j].Description
+		as := searchIndex[i].Title + searchIndex[i].Description + searchIndex[i].Href
+		bs := searchIndex[j].Title + searchIndex[j].Description + searchIndex[j].Href
+		return as > bs
 	})
 
 	return searchIndex

--- a/deploy.yml
+++ b/deploy.yml
@@ -677,6 +677,8 @@ objects:
                       required:
                       - APIKey
                       type: object
+                    cdnPath:
+                      type: string
                     config:
                       x-kubernetes-preserve-unknown-fields: true
                     defaultDocumentTitle:

--- a/tests/e2e/generate-search-index/02-assert.yaml
+++ b/tests/e2e/generate-search-index/02-assert.yaml
@@ -69,6 +69,6 @@ data:
   fed-modules.json: >-
     {"search":{"manifestLocation":"/apps/search/fed-mods.json","moduleID":"search","fullProfile":false,"cdnPath":"/apps/search/"}}
   search-index.json: >-
-    [{"id":"search-test-search-index-environment-landing","href":"/","title":"Landing","description":"Landing page description","alt_title":["HCC Home page","Home"],"frontendRef":"search"},{"id":"search-test-search-index-environment-landing-widgets","href":"/widgets","title":"Widget fantastic","description":"Widget","frontendRef":"search"}]
+    [{"id":"search-test-search-index-environment-landing-widgets","href":"/widgets","title":"Widget fantastic","description":"Widget","frontendRef":"search"},{"id":"search-test-search-index-environment-landing","href":"/","title":"Landing","description":"Landing page description","alt_title":["HCC Home page","Home"],"frontendRef":"search"}]
 
 


### PR DESCRIPTION
The previous condition was not "combining" the string and could exit early, which can cause items not to be in order and some reconcilination loops.