### PR TITLE
RHCLOUD-42256 setting timeout for the valpop job to 48 hours

### DIFF
--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -508,7 +508,7 @@ func (r *FrontendReconciliation) populatePushCacheContainer(j *batchv1.Job) erro
 	port := objectStoreInfo.Port
 
 	// Construct the pushcache startup command; removing the sleep command will result in the pushcache job being spin up continously, without delay, and uploading the assets to s3
-	command := fmt.Sprintf("sleep 120; valpop populate -r %s -s /srv/dist --timeout 100800 --bucket %s --hostname %s --port %s --username %s --password %s", r.Frontend.Name, *bucketName, *hostname, *port, *awsUsername, *awsPassword)
+	command := fmt.Sprintf("sleep 120; valpop populate -r %s -s /srv/dist --timeout 172800 --bucket %s --hostname %s --port %s --username %s --password %s", r.Frontend.Name, *bucketName, *hostname, *port, *awsUsername, *awsPassword)
 
 	volumeMounts := []v1.VolumeMount{}
 	volumeMounts = append(volumeMounts, v1.VolumeMount{

--- a/tests/e2e/pushcache/02-assert.yaml
+++ b/tests/e2e/pushcache/02-assert.yaml
@@ -89,7 +89,7 @@ spec:
           command:
             - /bin/bash
             - '-c'
-            - 'sleep 120; valpop populate -r chrome-test-defaults -s /srv/dist --timeout 100800 --bucket frontend --hostname minio-service.minio-env.svc.cluster.local --port 9000 --username minioadmin --password minioadmin'
+            - 'sleep 120; valpop populate -r chrome-test-defaults -s /srv/dist --timeout 172800 --bucket frontend --hostname minio-service.minio-env.svc.cluster.local --port 9000 --username minioadmin --password minioadmin'
           resources: {}
           volumeMounts:
             - name: pushcache-volume


### PR DESCRIPTION
The default timeout of 30 seconds on the valpop job is insufficient.