### PR TITLE
Ingress for reverse proxy

### DIFF
--- a/api/v1alpha1/frontendenvironment_types.go
+++ b/api/v1alpha1/frontendenvironment_types.go
@@ -135,6 +135,8 @@ type FrontendEnvironmentSpec struct {
 	ReverseProxySPAEntrypointPath string `json:"reverseProxySPAEntrypointPath,omitempty"`
 	// Log level for reverse proxy
 	ReverseProxyLogLevel string `json:"reverseProxyLogLevel,omitempty"`
+	// Hostname for reverse proxy ingress
+	ReverseProxyHostname string `json:"reverseProxyHostname,omitempty"`
 
 	DefaultReplicas *int32 `json:"defaultReplicas,omitempty" yaml:"defaultReplicas,omitempty"`
 	// For the ChromeUI to render navigation bundles

--- a/config/crd/bases/cloud.redhat.com_frontendenvironments.yaml
+++ b/config/crd/bases/cloud.redhat.com_frontendenvironments.yaml
@@ -160,6 +160,9 @@ spec:
                   x-kubernetes-int-or-string: true
                 description: ResourceList is a set of (resource name, quantity) pairs.
                 type: object
+              reverseProxyHostname:
+                description: Hostname for reverse proxy ingress
+                type: string
               reverseProxyImage:
                 description: Reverse Proxy Container Image
                 type: string

--- a/controllers/reconcile_reverse_proxy.go
+++ b/controllers/reconcile_reverse_proxy.go
@@ -808,7 +808,6 @@ func (r *ReverseProxyReconciliation) createReverseProxyIngress() error {
 	return r.Client.Create(r.Ctx, ingress)
 }
 
-
 // compareIngressFields compares the important fields of the current ingress against desired values
 func (r *ReverseProxyReconciliation) compareIngressFields(current *networkingv1.Ingress, desiredHost string, desiredLabels map[string]string) (bool, string) {
 	if len(current.Spec.Rules) != 1 {

--- a/controllers/reconcile_reverse_proxy.go
+++ b/controllers/reconcile_reverse_proxy.go
@@ -691,10 +691,10 @@ func (r *ReverseProxyReconciliation) createReverseProxyIngress() error {
 		"nginx.ingress.kubernetes.io/ssl-redirect":   "false",
 	}
 
-	// Get hostname
-	host := r.FrontendEnvironment.Spec.Hostname
+	// Get hostname for reverse proxy
+	host := r.FrontendEnvironment.Spec.ReverseProxyHostname
 	if host == "" {
-		host = r.Frontend.Spec.EnvName + ".local"
+		return fmt.Errorf("reverseProxyHostname must be specified in FrontendEnvironment spec when reverse proxy is enabled")
 	}
 
 	// Create ingress path
@@ -804,10 +804,10 @@ func (r *ReverseProxyReconciliation) createReverseProxyIngressConfig() (*network
 		"nginx.ingress.kubernetes.io/ssl-redirect":   "false",
 	}
 
-	// Get hostname
-	host := r.FrontendEnvironment.Spec.Hostname
+	// Get hostname for reverse proxy
+	host := r.FrontendEnvironment.Spec.ReverseProxyHostname
 	if host == "" {
-		host = r.Frontend.Spec.EnvName + ".local"
+		return nil, fmt.Errorf("reverseProxyHostname must be specified in FrontendEnvironment spec when reverse proxy is enabled")
 	}
 
 	// Create ingress path

--- a/controllers/reconcile_reverse_proxy.go
+++ b/controllers/reconcile_reverse_proxy.go
@@ -818,10 +818,7 @@ func (r *ReverseProxyReconciliation) buildReverseProxyIngress() (*networkingv1.I
 	labels := r.getReverseProxyLabels()
 
 	// Set up annotations
-	annotations := map[string]string{
-		"nginx.ingress.kubernetes.io/rewrite-target": "/",
-		"nginx.ingress.kubernetes.io/ssl-redirect":   "false",
-	}
+	annotations := map[string]string{}
 
 	// Get hostname for reverse proxy
 	host := r.FrontendEnvironment.Spec.ReverseProxyHostname
@@ -967,10 +964,7 @@ func (r *ReverseProxyReconciliation) compareIngressFields(current *networkingv1.
 	}
 
 	// Check important annotations
-	requiredAnnotations := map[string]string{
-		"nginx.ingress.kubernetes.io/rewrite-target": "/",
-		"nginx.ingress.kubernetes.io/ssl-redirect":   "false",
-	}
+	requiredAnnotations := map[string]string{}
 
 	// Add whitelist annotations if configured
 	if len(r.FrontendEnvironment.Spec.Whitelist) > 0 {

--- a/controllers/reconcile_reverse_proxy_test.go
+++ b/controllers/reconcile_reverse_proxy_test.go
@@ -969,10 +969,7 @@ func TestReverseProxyReconciliation_CompareIngressFields(t *testing.T) {
 	pathType := networkingv1.PathTypePrefix
 	baseIngress := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{
-				"nginx.ingress.kubernetes.io/rewrite-target": "/",
-				"nginx.ingress.kubernetes.io/ssl-redirect":   "false",
-			},
+			Annotations: map[string]string{},
 		},
 		Spec: networkingv1.IngressSpec{
 			Rules: []networkingv1.IngressRule{
@@ -1049,28 +1046,6 @@ func TestReverseProxyReconciliation_CompareIngressFields(t *testing.T) {
 			current: func() *networkingv1.Ingress {
 				ing := baseIngress.DeepCopy()
 				ing.Spec.Rules[0].HTTP.Paths[0].Path = "/wrong-path"
-				return ing
-			}(),
-			desiredHost:     "reverse-proxy.cluster.local",
-			desiredLabels:   map[string]string{},
-			expectDifferent: true,
-		},
-		{
-			name: "Missing required annotation",
-			current: func() *networkingv1.Ingress {
-				ing := baseIngress.DeepCopy()
-				delete(ing.Annotations, "nginx.ingress.kubernetes.io/rewrite-target")
-				return ing
-			}(),
-			desiredHost:     "reverse-proxy.cluster.local",
-			desiredLabels:   map[string]string{},
-			expectDifferent: true,
-		},
-		{
-			name: "Wrong annotation value",
-			current: func() *networkingv1.Ingress {
-				ing := baseIngress.DeepCopy()
-				ing.Annotations["nginx.ingress.kubernetes.io/ssl-redirect"] = "true"
 				return ing
 			}(),
 			desiredHost:     "reverse-proxy.cluster.local",

--- a/controllers/reconcile_reverse_proxy_test.go
+++ b/controllers/reconcile_reverse_proxy_test.go
@@ -782,10 +782,11 @@ func TestReverseProxyReconciliation_Ingress(t *testing.T) {
 			Name: "test-env",
 		},
 		Spec: crd.FrontendEnvironmentSpec{
-			EnablePushCache:   true,
-			ReverseProxyImage: "quay.io/test/reverse-proxy:latest",
-			Hostname:          "test.example.com",
-			SSL:               false,
+			EnablePushCache:      true,
+			ReverseProxyImage:    "quay.io/test/reverse-proxy:latest",
+			Hostname:             "test.example.com",
+			ReverseProxyHostname: "reverse-proxy.cluster.local",
+			SSL:                  false,
 		},
 	}
 
@@ -827,8 +828,8 @@ func TestReverseProxyReconciliation_Ingress(t *testing.T) {
 		}
 
 		// Verify ingress properties
-		if ingress.Spec.Rules[0].Host != "test.example.com" {
-			t.Errorf("Expected host=test.example.com, got host=%s", ingress.Spec.Rules[0].Host)
+		if ingress.Spec.Rules[0].Host != "reverse-proxy.cluster.local" {
+			t.Errorf("Expected host=reverse-proxy.cluster.local, got host=%s", ingress.Spec.Rules[0].Host)
 		}
 
 		if ingress.Spec.Rules[0].HTTP.Paths[0].Path != "/" {
@@ -878,8 +879,8 @@ func TestReverseProxyReconciliation_Ingress(t *testing.T) {
 			t.Errorf("Expected TLS secret=reverse-proxy-tls, got secret=%s", ingressConfig.Spec.TLS[0].SecretName)
 		}
 
-		if len(ingressConfig.Spec.TLS[0].Hosts) != 1 || ingressConfig.Spec.TLS[0].Hosts[0] != "test.example.com" {
-			t.Errorf("Expected TLS host=test.example.com, got hosts=%v", ingressConfig.Spec.TLS[0].Hosts)
+		if len(ingressConfig.Spec.TLS[0].Hosts) != 1 || ingressConfig.Spec.TLS[0].Hosts[0] != "reverse-proxy.cluster.local" {
+			t.Errorf("Expected TLS host=reverse-proxy.cluster.local, got hosts=%v", ingressConfig.Spec.TLS[0].Hosts)
 		}
 	})
 
@@ -937,8 +938,8 @@ func TestReverseProxyReconciliation_Ingress(t *testing.T) {
 		}
 
 		// Verify the host was updated
-		if updatedIngress.Spec.Rules[0].Host != "test.example.com" {
-			t.Errorf("Expected updated host=test.example.com, got host=%s", updatedIngress.Spec.Rules[0].Host)
+		if updatedIngress.Spec.Rules[0].Host != "reverse-proxy.cluster.local" {
+			t.Errorf("Expected updated host=reverse-proxy.cluster.local, got host=%s", updatedIngress.Spec.Rules[0].Host)
 		}
 	})
 }
@@ -958,7 +959,7 @@ func TestReverseProxyReconciliation_CompareIngress(t *testing.T) {
 		Spec: networkingv1.IngressSpec{
 			Rules: []networkingv1.IngressRule{
 				{
-					Host: "test.example.com",
+					Host: "reverse-proxy.cluster.local",
 					IngressRuleValue: networkingv1.IngressRuleValue{
 						HTTP: &networkingv1.HTTPIngressRuleValue{
 							Paths: []networkingv1.HTTPIngressPath{
@@ -1041,7 +1042,7 @@ func TestReverseProxyReconciliation_CompareIngress(t *testing.T) {
 				ing := baseIngress.DeepCopy()
 				ing.Spec.TLS = []networkingv1.IngressTLS{
 					{
-						Hosts:      []string{"test.example.com"},
+						Hosts:      []string{"reverse-proxy.cluster.local"},
 						SecretName: "test-tls",
 					},
 				}
@@ -1105,10 +1106,11 @@ func TestReverseProxyReconciliation_FullReconciliation(t *testing.T) {
 			Name: "test-env",
 		},
 		Spec: crd.FrontendEnvironmentSpec{
-			EnablePushCache:   true,
-			ReverseProxyImage: "quay.io/test/reverse-proxy:latest",
-			Hostname:          "test.example.com",
-			SSL:               false,
+			EnablePushCache:      true,
+			ReverseProxyImage:    "quay.io/test/reverse-proxy:latest",
+			Hostname:             "test.example.com",
+			ReverseProxyHostname: "reverse-proxy.cluster.local",
+			SSL:                  false,
 		},
 	}
 

--- a/controllers/reconcile_reverse_proxy_test.go
+++ b/controllers/reconcile_reverse_proxy_test.go
@@ -887,8 +887,8 @@ func TestReverseProxyReconciliation_Ingress(t *testing.T) {
 			t.Errorf("Expected 1 TLS entry, got %d", len(ingress.Spec.TLS))
 		}
 
-		if ingress.Spec.TLS[0].SecretName != "reverse-proxy-tls" {
-			t.Errorf("Expected TLS secret=reverse-proxy-tls, got secret=%s", ingress.Spec.TLS[0].SecretName)
+		if ingress.Spec.TLS[0].SecretName != "reverse-proxy-cert" {
+			t.Errorf("Expected TLS secret=reverse-proxy-cert, got secret=%s", ingress.Spec.TLS[0].SecretName)
 		}
 
 		if len(ingress.Spec.TLS[0].Hosts) != 1 || ingress.Spec.TLS[0].Hosts[0] != "reverse-proxy.cluster.local" {

--- a/deploy.yml
+++ b/deploy.yml
@@ -406,6 +406,9 @@ objects:
                   description: ResourceList is a set of (resource name, quantity)
                     pairs.
                   type: object
+                reverseProxyHostname:
+                  description: Hostname for reverse proxy ingress
+                  type: string
                 reverseProxyImage:
                   description: Reverse Proxy Container Image
                   type: string

--- a/examples/feenvironment.yaml
+++ b/examples/feenvironment.yaml
@@ -13,6 +13,7 @@ spec:
     "console.openshiftusgov.com": "https://sso.openshiftusgov.com"
   enablePushCache: true
   reverseProxyImage: quay.io/redhat-services-prod/hcc-platex-services-tenant/frontend-asset-proxy:latest
+  reverseProxyHostname: reverse-proxy.cluster.local
   reverseProxySPAEntrypointPath: /index.html
   reverseProxyLogLevel: DEBUG
   targetNamespaces:

--- a/tests/e2e/ingress-annotations/01-create-resources.yaml
+++ b/tests/e2e/ingress-annotations/01-create-resources.yaml
@@ -8,8 +8,6 @@ spec:
   ssl: false
   hostname: foo.redhat.com
   sso: https://sso.foo.redhat.com
-  ingressAnnotations:
-    "nginx.ingress.kubernetes.io/rewrite-target" : "/"
 ---
 apiVersion: cloud.redhat.com/v1alpha1
 kind: Frontend

--- a/tests/e2e/ingress-annotations/02-assert.yaml
+++ b/tests/e2e/ingress-annotations/02-assert.yaml
@@ -51,10 +51,3 @@ spec:
             - name: config-chrome
               mountPath: /srv/dist/operator-generated/fed-modules.json
               subPath: fed-modules.json
----
-kind: Ingress
-apiVersion: networking.k8s.io/v1
-metadata:
-  namespace: test-ingress-annotations
-  annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /

--- a/tests/e2e/reverse-proxy/01-create-resources.yaml
+++ b/tests/e2e/reverse-proxy/01-create-resources.yaml
@@ -8,6 +8,7 @@ spec:
   generateNavJSON: false
   ssl: false
   hostname: reverse-proxy-test.example.com
+  reverseProxyHostname: reverse-proxy.cluster.local
   sso: https://sso.foo.redhat.com
   enablePushCache: true
   reverseProxyImage: quay.io/redhatinsights/frontend-asset-proxy:latest

--- a/tests/e2e/reverse-proxy/01-create-resources.yaml
+++ b/tests/e2e/reverse-proxy/01-create-resources.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   generateNavJSON: false
   ssl: false
-  hostname: foo.redhat.com
+  hostname: reverse-proxy-test.example.com
   sso: https://sso.foo.redhat.com
   enablePushCache: true
   reverseProxyImage: quay.io/redhatinsights/frontend-asset-proxy:latest

--- a/tests/e2e/reverse-proxy/02-assert.yaml
+++ b/tests/e2e/reverse-proxy/02-assert.yaml
@@ -163,7 +163,7 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   rules:
-  - host: reverse-proxy-test.example.com
+  - host: reverse-proxy.cluster.local
     http:
       paths:
       - path: /

--- a/tests/e2e/reverse-proxy/02-assert.yaml
+++ b/tests/e2e/reverse-proxy/02-assert.yaml
@@ -158,9 +158,6 @@ metadata:
     app: reverse-proxy
     component: reverse-proxy
     environment: test-reverse-proxy-environment
-  annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   rules:
   - host: reverse-proxy.cluster.local

--- a/tests/e2e/reverse-proxy/02-assert.yaml
+++ b/tests/e2e/reverse-proxy/02-assert.yaml
@@ -147,3 +147,29 @@ spec:
     environment: test-reverse-proxy-environment
     app: reverse-proxy
     component: reverse-proxy
+---
+# Verify that the reverse proxy ingress was created
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: reverse-proxy
+  namespace: test-reverse-proxy
+  labels:
+    app: reverse-proxy
+    component: reverse-proxy
+    environment: test-reverse-proxy-environment
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  rules:
+  - host: reverse-proxy-test.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: reverse-proxy
+            port:
+              number: 8080

--- a/tests/e2e/reverse-proxy/03-enable-ssl.yaml
+++ b/tests/e2e/reverse-proxy/03-enable-ssl.yaml
@@ -10,6 +10,7 @@ spec:
   hostname: reverse-proxy-test.example.com
   sso: https://sso.foo.redhat.com
   enablePushCache: true
+  reverseProxyHostname: reverse-proxy.cluster.local
   reverseProxyImage: quay.io/redhatinsights/frontend-asset-proxy:latest
   reverseProxySPAEntrypointPath: /index.html
   reverseProxyLogLevel: INFO

--- a/tests/e2e/reverse-proxy/03-enable-ssl.yaml
+++ b/tests/e2e/reverse-proxy/03-enable-ssl.yaml
@@ -1,0 +1,15 @@
+---
+# Test SSL configuration by updating the FrontendEnvironment
+apiVersion: cloud.redhat.com/v1alpha1
+kind: FrontendEnvironment
+metadata:
+  name: test-reverse-proxy-environment
+spec:
+  generateNavJSON: false
+  ssl: true  # Enable SSL
+  hostname: reverse-proxy-test.example.com
+  sso: https://sso.foo.redhat.com
+  enablePushCache: true
+  reverseProxyImage: quay.io/redhatinsights/frontend-asset-proxy:latest
+  reverseProxySPAEntrypointPath: /index.html
+  reverseProxyLogLevel: INFO

--- a/tests/e2e/reverse-proxy/04-assert-ssl.yaml
+++ b/tests/e2e/reverse-proxy/04-assert-ssl.yaml
@@ -15,10 +15,10 @@ metadata:
 spec:
   tls:
   - hosts:
-    - reverse-proxy-test.example.com
+    - reverse-proxy.cluster.local
     secretName: reverse-proxy-tls
   rules:
-  - host: reverse-proxy-test.example.com
+  - host: reverse-proxy.cluster.local
     http:
       paths:
       - path: /

--- a/tests/e2e/reverse-proxy/04-assert-ssl.yaml
+++ b/tests/e2e/reverse-proxy/04-assert-ssl.yaml
@@ -9,9 +9,6 @@ metadata:
     app: reverse-proxy
     component: reverse-proxy
     environment: test-reverse-proxy-environment
-  annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   tls:
   - hosts:

--- a/tests/e2e/reverse-proxy/04-assert-ssl.yaml
+++ b/tests/e2e/reverse-proxy/04-assert-ssl.yaml
@@ -16,7 +16,7 @@ spec:
   tls:
   - hosts:
     - reverse-proxy.cluster.local
-    secretName: reverse-proxy-tls
+    secretName: reverse-proxy-cert
   rules:
   - host: reverse-proxy.cluster.local
     http:

--- a/tests/e2e/reverse-proxy/04-assert-ssl.yaml
+++ b/tests/e2e/reverse-proxy/04-assert-ssl.yaml
@@ -1,0 +1,30 @@
+---
+# Verify that the ingress was updated with TLS configuration
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: reverse-proxy
+  namespace: test-reverse-proxy
+  labels:
+    app: reverse-proxy
+    component: reverse-proxy
+    environment: test-reverse-proxy-environment
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  tls:
+  - hosts:
+    - reverse-proxy-test.example.com
+    secretName: reverse-proxy-tls
+  rules:
+  - host: reverse-proxy-test.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: reverse-proxy
+            port:
+              number: 8080


### PR DESCRIPTION
Adds ingress for the reverse proxy so we can communicate with the pod from akamai
- ReverseProxyHostname is used so we don't override the current ingresses at hostname. Another alternative is to have the ingress on current_hostname/reverse-proxy. this would need an akamai rewrite and something similar in other environments. I preferred keeping it in the operator below.
- Adds the whitelist annotations
- A bit of code dedicated for checking the ingress fields and making sure they havent changed.
