### PR TITLE
Removing specific TLS definition in ingress

### DIFF
--- a/controllers/reconcile_reverse_proxy.go
+++ b/controllers/reconcile_reverse_proxy.go
@@ -1095,11 +1095,6 @@ func (r *ReverseProxyReconciliation) compareIngressFields(current *networkingv1.
 		if len(tlsEntry.Hosts) != 0 {
 			return true, fmt.Sprintf("expected empty hosts array in TLS, found %d hosts", len(tlsEntry.Hosts))
 		}
-
-		// The SecretName should be empty when using OpenShift service serving certs
-		if tlsEntry.SecretName != "" {
-			return true, fmt.Sprintf("expected empty TLS secret name, found %s", tlsEntry.SecretName)
-		}
 	}
 
 	return false, ""

--- a/controllers/reconcile_reverse_proxy.go
+++ b/controllers/reconcile_reverse_proxy.go
@@ -920,12 +920,9 @@ func (r *ReverseProxyReconciliation) buildReverseProxyIngress() (*networkingv1.I
 
 	// Add TLS configuration if SSL is enabled
 	if r.FrontendEnvironment.Spec.SSL {
-		ingress.Spec.TLS = []networkingv1.IngressTLS{
-			{
-				Hosts:      []string{host},
-				SecretName: "reverse-proxy-cert",
-			},
-		}
+		ingress.Spec.TLS = []networkingv1.IngressTLS{{
+			Hosts: []string{},
+		}}
 	}
 
 	// Set owner reference to the environment instead of the frontend
@@ -1071,28 +1068,6 @@ func (r *ReverseProxyReconciliation) compareIngressFields(current *networkingv1.
 		}
 		if currentValue != desiredValue {
 			return true, fmt.Sprintf("label %s changed from %s to %s", label, currentValue, desiredValue)
-		}
-	}
-
-	// Check TLS configuration
-	sslEnabled := r.FrontendEnvironment.Spec.SSL
-	hasTLS := len(current.Spec.TLS) > 0
-
-	if sslEnabled && !hasTLS {
-		return true, "SSL enabled but TLS configuration missing"
-	}
-
-	if !sslEnabled && hasTLS {
-		return true, "SSL disabled but TLS configuration present"
-	}
-
-	if sslEnabled && hasTLS {
-		if len(current.Spec.TLS[0].Hosts) == 0 || current.Spec.TLS[0].Hosts[0] != desiredHost {
-			return true, "TLS hostname mismatch"
-		}
-		expectedSecretName := "reverse-proxy-cert"
-		if current.Spec.TLS[0].SecretName != expectedSecretName {
-			return true, fmt.Sprintf("TLS secret name changed from %s to %s", current.Spec.TLS[0].SecretName, expectedSecretName)
 		}
 	}
 

--- a/controllers/reconcile_reverse_proxy_test.go
+++ b/controllers/reconcile_reverse_proxy_test.go
@@ -844,11 +844,6 @@ func TestReverseProxyReconciliation_Ingress(t *testing.T) {
 		if ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Port.Number != ReverseProxyPort {
 			t.Errorf("Expected port=%d, got port=%d", ReverseProxyPort, ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Port.Number)
 		}
-
-		// Verify no TLS since SSL is false
-		if len(ingress.Spec.TLS) != 0 {
-			t.Errorf("Expected no TLS configuration, got %d TLS entries", len(ingress.Spec.TLS))
-		}
 	})
 
 	t.Run("CreateIngressWithSSL", func(t *testing.T) {
@@ -880,19 +875,6 @@ func TestReverseProxyReconciliation_Ingress(t *testing.T) {
 		err = client.Get(context.Background(), ingressKey, ingress)
 		if err != nil {
 			t.Fatalf("Failed to get ingress: %v", err)
-		}
-
-		// Verify TLS configuration is added
-		if len(ingress.Spec.TLS) != 1 {
-			t.Errorf("Expected 1 TLS entry, got %d", len(ingress.Spec.TLS))
-		}
-
-		if ingress.Spec.TLS[0].SecretName != "reverse-proxy-cert" {
-			t.Errorf("Expected TLS secret=reverse-proxy-cert, got secret=%s", ingress.Spec.TLS[0].SecretName)
-		}
-
-		if len(ingress.Spec.TLS[0].Hosts) != 1 || ingress.Spec.TLS[0].Hosts[0] != "reverse-proxy.cluster.local" {
-			t.Errorf("Expected TLS host=reverse-proxy.cluster.local, got hosts=%v", ingress.Spec.TLS[0].Hosts)
 		}
 	})
 

--- a/tests/e2e/reverse-proxy/04-assert-ssl.yaml
+++ b/tests/e2e/reverse-proxy/04-assert-ssl.yaml
@@ -11,9 +11,7 @@ metadata:
     environment: test-reverse-proxy-environment
 spec:
   tls:
-  - hosts:
-    - reverse-proxy.cluster.local
-    secretName: reverse-proxy-cert
+  - {}
   rules:
   - host: reverse-proxy.cluster.local
     http:


### PR DESCRIPTION
This is to further match the frontends. After this they are exactly the same...

Never using generated code again haha