### PR TITLE
Migrate .tekton pipelines from hcm-eng-prod-tenant to hcc-platex-services-tenant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ artifacts/
 build/.build_venv
 
 kuttl-report.json
+
+# Project tmp folder
+/tmp

--- a/.tekton/frontend-operator-pull-request.yaml
+++ b/.tekton/frontend-operator-pull-request.yaml
@@ -14,7 +14,7 @@ metadata:
     appstudio.openshift.io/component: frontend-operator
     pipelines.appstudio.openshift.io/type: build
   name: frontend-operator-on-pull-request
-  namespace: hcm-eng-prod-tenant
+  namespace: hcc-platex-services-tenant
 spec:
   params:
   - name: git-url
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcm-eng-prod-tenant/frontend-operator/frontend-operator:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-platex-services-tenant/frontend-operator/frontend-operator:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/frontend-operator-push.yaml
+++ b/.tekton/frontend-operator-push.yaml
@@ -13,7 +13,7 @@ metadata:
     appstudio.openshift.io/component: frontend-operator
     pipelines.appstudio.openshift.io/type: build
   name: frontend-operator-on-push
-  namespace: hcm-eng-prod-tenant
+  namespace: hcc-platex-services-tenant
 spec:
   params:
   - name: git-url
@@ -21,7 +21,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcm-eng-prod-tenant/frontend-operator/frontend-operator:{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-platex-services-tenant/frontend-operator/frontend-operator:{{revision}}
   - name: dockerfile
     value: Dockerfile
   pipelineSpec:

--- a/.tekton/frontend-operator-sc-pull-request.yaml
+++ b/.tekton/frontend-operator-sc-pull-request.yaml
@@ -15,7 +15,7 @@ metadata:
     appstudio.openshift.io/component: frontend-operator-sc
     pipelines.appstudio.openshift.io/type: build
   name: frontend-operator-sc-on-pull-request
-  namespace: hcm-eng-prod-tenant
+  namespace: hcc-platex-services-tenant
 spec:
   params:
   - name: git-url
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcm-eng-prod-tenant/frontend-operator-sc/frontend-operator-sc:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-platex-services-tenant/frontend-operator-sc/frontend-operator-sc:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/frontend-operator-sc-push.yaml
+++ b/.tekton/frontend-operator-sc-push.yaml
@@ -14,7 +14,7 @@ metadata:
     appstudio.openshift.io/component: frontend-operator-sc
     pipelines.appstudio.openshift.io/type: build
   name: frontend-operator-sc-on-push
-  namespace: hcm-eng-prod-tenant
+  namespace: hcc-platex-services-tenant
 spec:
   params:
   - name: git-url
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/hcm-eng-prod-tenant/frontend-operator-sc/frontend-operator-sc:{{revision}}
+    value: quay.io/redhat-user-workloads/hcc-platex-services-tenant/frontend-operator-sc/frontend-operator-sc:{{revision}}
   - name: dockerfile
     value: Dockerfile
   - name: path-context


### PR DESCRIPTION
Update namespace and output-image in all four .tekton pipeline files to reflect  the tenant migration completed in app-interface (RHCLOUD-45612).

https://issues.redhat.com/browse/RHCLOUD-45613
