### PR TITLE
fix: wrap SetFrontendConditions in RetryOnConflict to handle stale resourceVersion

### DIFF
--- a/controllers/status.go
+++ b/controllers/status.go
@@ -11,76 +11,88 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func SetFrontendConditions(ctx context.Context, client client.Client, o *crd.Frontend, state string, err error) error {
-	oldStatus := o.Status.DeepCopy()
-	conditions := []metav1.Condition{}
-
-	loopConditions := []string{crd.ReconciliationSuccessful, crd.ReconciliationFailed}
-	for _, conditionType := range loopConditions {
-		condition := &metav1.Condition{}
-		condition.Type = conditionType
-		condition.Status = metav1.ConditionFalse
-		condition.Reason = "NoError"
-
-		if state == conditionType {
-			condition.Status = metav1.ConditionTrue
-			if err != nil {
-				condition.Message = err.Error()
-				condition.Reason = "Error"
-			}
-		}
-
-		condition.LastTransitionTime = metav1.Now()
-		conditions = append(conditions, *condition)
-	}
-
-	frontendStatus, err := GetFrontendResources(ctx, client, o)
-	if err != nil {
-		return err
-	}
-
-	condition := &metav1.Condition{}
-
-	condition.Reason = "NoError"
-	condition.Status = metav1.ConditionFalse
-	condition.Message = "Deployments are not yet ready"
-	if frontendStatus {
-		condition.Status = metav1.ConditionTrue
-		condition.Message = "All managed deployments ready"
-	}
-
-	condition.Type = crd.FrontendsReady
-	condition.LastTransitionTime = metav1.Now()
-	//FIXME: condition is always false
-	if err != nil {
-		condition.Message += err.Error()
-		condition.Reason = "Error"
-	}
-
-	conditions = append(conditions, *condition)
-	for _, condition := range conditions {
-		innerCondition := condition
-		meta.SetStatusCondition(&o.Status.Conditions, innerCondition)
-	}
-
-	o.Status.Ready = frontendStatus
-	stats, _, err := GetFrontendFigures(ctx, client, o)
-	if err != nil {
-		return err
-	}
-
-	o.Status.Deployments.ManagedDeployments = stats.ManagedDeployments
-	o.Status.Deployments.ReadyDeployments = stats.ReadyDeployments
-
-	if !equality.Semantic.DeepEqual(*oldStatus, o.Status) {
-		if err := client.Status().Update(ctx, o); err != nil {
+func SetFrontendConditions(ctx context.Context, client client.Client, o *crd.Frontend, state string, conditionErr error) error {
+	// RetryOnConflict handles 409 conflicts caused by the Frontend CR's
+	// resourceVersion changing between the reconciler's initial Get and this
+	// status update (e.g. annotation changes, concurrent reconcilers).
+	// Each retry re-fetches the Frontend to get the latest resourceVersion.
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := client.Get(ctx, types.NamespacedName{Name: o.Name, Namespace: o.Namespace}, o); err != nil {
 			return err
 		}
-	}
-	return nil
+
+		oldStatus := o.Status.DeepCopy()
+		conditions := []metav1.Condition{}
+
+		loopConditions := []string{crd.ReconciliationSuccessful, crd.ReconciliationFailed}
+		for _, conditionType := range loopConditions {
+			condition := &metav1.Condition{}
+			condition.Type = conditionType
+			condition.Status = metav1.ConditionFalse
+			condition.Reason = "NoError"
+
+			if state == conditionType {
+				condition.Status = metav1.ConditionTrue
+				if conditionErr != nil {
+					condition.Message = conditionErr.Error()
+					condition.Reason = "Error"
+				}
+			}
+
+			condition.LastTransitionTime = metav1.Now()
+			conditions = append(conditions, *condition)
+		}
+
+		frontendStatus, err := GetFrontendResources(ctx, client, o)
+		if err != nil {
+			return err
+		}
+
+		condition := &metav1.Condition{}
+
+		condition.Reason = "NoError"
+		condition.Status = metav1.ConditionFalse
+		condition.Message = "Deployments are not yet ready"
+		if frontendStatus {
+			condition.Status = metav1.ConditionTrue
+			condition.Message = "All managed deployments ready"
+		}
+
+		condition.Type = crd.FrontendsReady
+		condition.LastTransitionTime = metav1.Now()
+		//FIXME: condition is always false
+		if err != nil {
+			condition.Message += err.Error()
+			condition.Reason = "Error"
+		}
+
+		conditions = append(conditions, *condition)
+		for _, condition := range conditions {
+			innerCondition := condition
+			meta.SetStatusCondition(&o.Status.Conditions, innerCondition)
+		}
+
+		o.Status.Ready = frontendStatus
+		stats, _, err := GetFrontendFigures(ctx, client, o)
+		if err != nil {
+			return err
+		}
+
+		o.Status.Deployments.ManagedDeployments = stats.ManagedDeployments
+		o.Status.Deployments.ReadyDeployments = stats.ReadyDeployments
+
+		if !equality.Semantic.DeepEqual(*oldStatus, o.Status) {
+			if err := client.Status().Update(ctx, o); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 func GetFrontendResources(ctx context.Context, client client.Client, o *crd.Frontend) (bool, error) {

--- a/controllers/status_conflict_test.go
+++ b/controllers/status_conflict_test.go
@@ -1,0 +1,159 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	crd "github.com/RedHatInsights/frontend-operator/api/v1alpha1"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// This file reproduces RHCLOUD-46529: SetFrontendConditions calls
+// client.Status().Update() using a Frontend object whose resourceVersion may
+// be stale. When an external write (annotation change, concurrent reconciler)
+// bumps the CR's resourceVersion between the reconciler's initial Get and the
+// status update, the API server returns a 409 Conflict.
+//
+// Before the fix: SetFrontendConditions propagates the 409 → tests FAIL.
+// After the fix: SetFrontendConditions wraps the update in
+//   retry.RetryOnConflict with a re-fetch → tests PASS.
+
+// statusConflictWriter wraps a SubResourceWriter and injects 409 Conflict
+// errors on the first N Update calls targeting Frontend objects.
+type statusConflictWriter struct {
+	client.SubResourceWriter
+	conflictsRemaining atomic.Int32
+}
+
+func (w *statusConflictWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	if _, ok := obj.(*crd.Frontend); ok {
+		if w.conflictsRemaining.Add(-1) >= 0 {
+			return k8serr.NewConflict(
+				schema.GroupResource{Group: "cloud.redhat.com", Resource: "frontends"},
+				obj.GetName(),
+				fmt.Errorf("the object has been modified; please apply your changes to the latest version and try again"),
+			)
+		}
+	}
+	return w.SubResourceWriter.Update(ctx, obj, opts...)
+}
+
+// statusConflictClient wraps a client.Client and overrides Status() to return
+// a writer that injects 409 conflicts on Frontend status updates.
+type statusConflictClient struct {
+	client.Client
+	writer *statusConflictWriter
+}
+
+func (c *statusConflictClient) Status() client.SubResourceWriter {
+	return c.writer
+}
+
+var _ = ginkgo.Describe("Status update conflict (RHCLOUD-46529)", func() {
+	ctx := context.Background()
+	ns := "default"
+
+	ginkgo.It("should retry SetFrontendConditions when resourceVersion is stale", func() {
+		envName := "status-conflict-env-1"
+		frontendName := "status-conflict-fe-1"
+
+		createConflictTestResources(ctx, k8sClient, envName, frontendName, ns)
+
+		// Wait for the manager's controller to finish initial reconciliation
+		// so that field indexes are populated and GetFrontendFigures works.
+		gomega.Eventually(func() bool {
+			fe := &crd.Frontend{}
+			if err := k8sManagerClient.Get(ctx, types.NamespacedName{Name: frontendName, Namespace: ns}, fe); err != nil {
+				return false
+			}
+			for _, c := range fe.Status.Conditions {
+				if c.Type == crd.ReconciliationSuccessful && c.Status == metav1.ConditionTrue {
+					return true
+				}
+			}
+			return false
+		}, 30*time.Second, 100*time.Millisecond).Should(gomega.BeTrue(),
+			"Initial reconciliation should succeed")
+
+		// Simulate the race: fetch the Frontend, bump resourceVersion with
+		// an annotation (simulates external write), then call
+		// SetFrontendConditions with the stale object.
+		fe := &crd.Frontend{}
+		gomega.Expect(k8sManagerClient.Get(ctx, types.NamespacedName{Name: frontendName, Namespace: ns}, fe)).To(gomega.Succeed())
+
+		staleFrontend := fe.DeepCopy()
+
+		// Bump resourceVersion by annotating the Frontend.
+		if fe.Annotations == nil {
+			fe.Annotations = map[string]string{}
+		}
+		fe.Annotations["test-bump"] = "force-rv-change"
+		gomega.Expect(k8sManagerClient.Update(ctx, fe)).To(gomega.Succeed())
+
+		// Clear conditions on the stale copy so SetFrontendConditions sees a
+		// status diff and actually calls Status().Update() (otherwise DeepEqual
+		// skips the update and the stale resourceVersion is never tested).
+		staleFrontend.Status.Conditions = nil
+
+		// staleFrontend now has a stale resourceVersion.
+		// Before the fix: returns 409 because Status().Update uses stale rv.
+		// After the fix: re-fetches and retries → succeeds.
+		err := SetFrontendConditions(ctx, k8sManagerClient, staleFrontend, crd.ReconciliationSuccessful, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+			"SetFrontendConditions should handle stale resourceVersion via retry")
+	})
+
+	ginkgo.It("should propagate status 409 through the reconciler error path", func() {
+		envName := "status-conflict-env-2"
+		frontendName := "status-conflict-fe-2"
+
+		createConflictTestResources(ctx, k8sClient, envName, frontendName, ns)
+
+		// Inject status conflicts AND deploy conflicts.
+		// Deploy conflicts (100) exhaust all retries → retryErr != nil.
+		// Then SetFrontendConditions is called on the error path (line 231)
+		// to report the failure, but status 409 makes that fail too.
+		deployCC := &conflictClient{Client: k8sManagerClient}
+		deployCC.conflictsRemaining.Store(100)
+
+		writer := &statusConflictWriter{
+			SubResourceWriter: k8sManagerClient.Status(),
+		}
+		writer.conflictsRemaining.Store(2)
+
+		cc := &statusConflictClient{
+			Client: deployCC,
+			writer: writer,
+		}
+
+		reconciler := &FrontendReconciler{
+			Client: cc,
+			Scheme: scheme,
+			Log:    ctrl.Log.WithName("status-conflict-test"),
+		}
+
+		_, reconcileErr := reconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: frontendName, Namespace: ns},
+		})
+
+		gomega.Expect(reconcileErr).To(gomega.HaveOccurred(),
+			"Reconcile should return an error")
+
+		// Before the fix: the error wraps "error setting status" because
+		//   SetFrontendConditions propagates the 409 on the error path.
+		// After the fix: SetFrontendConditions retries past the status 409,
+		//   successfully reports the failed condition, and returns the original
+		//   deploy conflict error (no "error setting status" wrapper).
+		gomega.Expect(reconcileErr.Error()).NotTo(gomega.ContainSubstring("error setting status"),
+			"Status update should succeed via retry; error should be the original reconciliation failure, not a status update failure")
+	})
+})


### PR DESCRIPTION
## Summary
  - `SetFrontendConditions` called `Status().Update()` with a potentially stale `resourceVersion`, causing 409 conflicts when annotations or concurrent reconcilers bumped the Frontend CR mid-reconciliation
  - Wrapped the status update in `retry.RetryOnConflict` with a re-fetch to get the latest `resourceVersion` before each attempt
  - Added tests that reproduce the 409 by bumping `resourceVersion` via annotation before calling `SetFrontendConditions` with the stale object
  -  Deployed on-pr image to stage envs. Logs look good and recons ran as expected. 

  ## Related
  - Parent: RHCLOUD-46019
  - RHCLOUD-46491 (retry on reconciliation body)
  - RHCLOUD-46492 (GenerationChangedPredicate on Owns watches)