### PR TITLE
docs: fix local dev setup in README and add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ This is unrelated to `metrics-server`. To silence it, install the Prometheus Ope
 → Full reset: `minikube delete --purge && minikube config set rootless true && minikube start --driver=podman`
 
 **`ValpopImage must be specified in the FrontendEnvironment when PushCache is enabled`**
-→ `examples/feenvironment.yaml` has `enablePushCache: true`. Set it to `false` for local dev, or add `valpopImage: quay.io/redhat-services-prod/hcc-platex-services-tenant/valpop:latest`. Re-apply: `oc apply -f examples/feenvironment.yaml -n boot`
+→ `valpopImage` is missing from `examples/feenvironment.yaml`. Add `valpopImage: quay.io/redhat-services-prod/hcc-platex-services-tenant/valpop:latest`. Re-apply: `oc apply -f examples/feenvironment.yaml -n boot`
 
 **Resource exhaustion / OOMKilled / cluster instability**
 → Beef up the podman machine and minikube resources:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,11 @@ minikube config set rootless true
 minikube start --driver=podman --container-runtime=cri-o
 ```
 
+The operator creates Ingress resources (nginx ingress class) for each Frontend and the reverse proxy. Enable the ingress addon if you want frontends accessible in the browser — not required for operator development:
+```sh
+minikube addons enable ingress
+```
+
 ### 3. Verify you're talking to minikube — do this at the start of every session
 ```sh
 kubectl config current-context   # must show "minikube"
@@ -47,6 +52,29 @@ make run-local 2>&1 | grep -v "level\":\"info\""  # filter if too noisy
 kubectl apply -f config/crd/test-resources/
 watch -n 0.1 'kubectl annotate frontend inventory -n default force-conflict=$(date +%s) --overwrite'
 ```
+
+## Optional minikube addons
+
+Enable these as needed depending on what you're working on:
+
+```sh
+# Required to access deployed frontends in the browser (operator creates nginx Ingress resources)
+minikube addons enable ingress
+
+# Useful for building and pushing custom operator or frontend images locally
+minikube addons enable registry
+
+# Enables kubectl top and HPA (horizontal pod autoscaler) support
+minikube addons enable metrics-server
+```
+
+`--disable-optimizations` can be passed to `minikube start` for more production-like cluster behaviour.
+
+**ServiceMonitor CRD warning** — the operator logs a non-fatal error on startup if the Prometheus Operator CRDs are not installed:
+```
+no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
+```
+This is unrelated to `metrics-server`. To silence it, install the Prometheus Operator CRDs. Safe to ignore for most local development.
 
 ## Common Failures
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ This is unrelated to `metrics-server`. To silence it, install the Prometheus Ope
 → Full reset: `minikube delete --purge && minikube config set rootless true && minikube start --driver=podman`
 
 **`ValpopImage must be specified in the FrontendEnvironment when PushCache is enabled`**
-→ `examples/feenvironment.yaml` has `enablePushCache: true`. Set it to `false` for local dev, or add a `valpopImage` field pointing to the valpop image. Re-apply: `oc apply -f examples/feenvironment.yaml -n boot`
+→ `examples/feenvironment.yaml` has `enablePushCache: true`. Set it to `false` for local dev, or add `valpopImage: quay.io/redhat-services-prod/hcc-platex-services-tenant/valpop:latest`. Re-apply: `oc apply -f examples/feenvironment.yaml -n boot`
 
 **Resource exhaustion / OOMKilled / cluster instability**
 → Beef up the podman machine and minikube resources:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,17 +25,21 @@ kubectl config current-context   # must show "minikube"
 kubectl config use-context minikube
 ```
 
-### 4. Create the boot namespace and install resources
-`make create-boot-namespace` creates the `boot` namespace (note: `env-boot` is the FrontendEnvironment resource name, not a namespace).
-It also regenerates manifests as a side effect.
+### 4. Create namespaces and install resources
+`make create-namespaces` creates both the `boot` and `env-boot` namespaces and regenerates manifests as a side effect.
+Note: `env-boot` is also the FrontendEnvironment resource name — both the namespace and the resource are required.
 ```sh
-make create-boot-namespace
+make create-namespaces
 make install-resources
 ```
 
 ### 5. Run the operator (terminal 1)
+`make run-local` defaults to Info log level (`--log-level 0`). Use `--log-level -1` for Debug output.
+Available levels: `-1` Debug, `0` Info, `1` Warn, `2` Error.
 ```sh
 make run-local
+# or for debug:
+make run-local 2>&1 | grep -v "level\":\"info\""  # filter if too noisy
 ```
 
 ### 6. Exercise it (terminal 2)
@@ -54,6 +58,9 @@ watch -n 0.1 'kubectl annotate frontend inventory -n default force-conflict=$(da
 
 **`no container with name or ID "minikube" found`**
 → Full reset: `minikube delete --purge && minikube config set rootless true && minikube start --driver=podman`
+
+**`ValpopImage must be specified in the FrontendEnvironment when PushCache is enabled`**
+→ `examples/feenvironment.yaml` has `enablePushCache: true`. Set it to `false` for local dev, or add a `valpopImage` field pointing to the valpop image. Re-apply: `oc apply -f examples/feenvironment.yaml -n boot`
 
 **Resource exhaustion / OOMKilled / cluster instability**
 → Beef up the podman machine and minikube resources:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,81 @@
+# frontend-operator Local Development
+
+## Prerequisites
+- podman (rootless mode required)
+- minikube
+- oc (OpenShift CLI) — resource commands use `oc`, not `kubectl`
+- kubectl — for cluster verification and context management
+
+## Initial Setup
+
+### 1. Configure minikube for rootless podman (once per machine)
+```sh
+minikube config set rootless true
+```
+
+### 2. Start the cluster
+```sh
+minikube start --driver=podman --container-runtime=cri-o
+```
+
+### 3. Verify you're talking to minikube — do this at the start of every session
+```sh
+kubectl config current-context   # must show "minikube"
+# If not:
+kubectl config use-context minikube
+```
+
+### 4. Create the boot namespace and install resources
+`make create-boot-namespace` creates the `boot` namespace (note: `env-boot` is the FrontendEnvironment resource name, not a namespace).
+It also regenerates manifests as a side effect.
+```sh
+make create-boot-namespace
+make install-resources
+```
+
+### 5. Run the operator (terminal 1)
+```sh
+make run-local
+```
+
+### 6. Exercise it (terminal 2)
+```sh
+kubectl apply -f config/crd/test-resources/
+watch -n 0.1 'kubectl annotate frontend inventory -n default force-conflict=$(date +%s) --overwrite'
+```
+
+## Common Failures
+
+**`PROVIDER_PODMAN_NOT_RUNNING: sudo -n -k podman version` exit status 1**
+→ podman is not configured for rootless mode: `minikube config set rootless true`
+
+**`volume with name minikube already exists`**
+→ `podman volume rm minikube` then retry `minikube start`
+
+**`no container with name or ID "minikube" found`**
+→ Full reset: `minikube delete --purge && minikube config set rootless true && minikube start --driver=podman`
+
+**Resource exhaustion / OOMKilled / cluster instability**
+→ Beef up the podman machine and minikube resources:
+```sh
+# Stop the cluster first
+minikube stop
+podman machine stop
+
+# Set podman machine resources
+podman machine set --cpus 6 --disk-size 100 --memory 20000
+
+# Set minikube resources (persisted in config)
+minikube config set cpus 4
+minikube config set memory 16000
+minikube config set disk-size 36GB
+
+podman machine start
+minikube start --driver=podman --container-runtime=cri-o
+```
+
+## Context Safety
+Always verify context before applying resources — a wrong context means you're targeting a real cluster.
+```sh
+kubectl config current-context   # must be "minikube"
+```

--- a/Makefile
+++ b/Makefile
@@ -137,14 +137,17 @@ docker-build: test ## Build docker image with the manager.
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
 
-create-boot-namespace: manifests generate fmt vet
+create-namespaces: manifests generate fmt vet
 	oc create namespace boot
+	oc create namespace env-boot
+
+create-boot-namespace: create-namespaces ## Deprecated: use create-namespaces
 
 install-resources:
 	oc apply -f config/crd/bases/cloud.redhat.com_frontends.yaml
 	oc apply -f config/crd/bases/cloud.redhat.com_frontendenvironments.yaml
 	oc apply -f config/crd/bases/cloud.redhat.com_bundles.yaml
-	oc apply -f examples/clowdenvironment.yaml
+	# oc apply -f examples/clowdenvironment.yaml
 	oc apply -f examples/feenvironment.yaml -n boot
 	oc apply -f examples/minio.yaml
 	oc apply -f examples/minio-bucket-secret.yaml -n boot
@@ -153,7 +156,7 @@ install-resources:
 	oc apply -f examples/chrome.yaml -n boot
 
 run-local:
-	$(PUSHCACHE_ENVS) $(GO_CMD) run ./main.go --metrics-bind-address :9090 --health-probe-bind-address :9091
+	$(PUSHCACHE_ENVS) $(GO_CMD) run ./main.go --metrics-bind-address :9090 --health-probe-bind-address :9091 --log-level 0
 
 ##@ Deployment
 

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,6 @@ install-resources:
 	oc apply -f config/crd/bases/cloud.redhat.com_frontends.yaml
 	oc apply -f config/crd/bases/cloud.redhat.com_frontendenvironments.yaml
 	oc apply -f config/crd/bases/cloud.redhat.com_bundles.yaml
-	# oc apply -f examples/clowdenvironment.yaml
 	oc apply -f examples/feenvironment.yaml -n boot
 	oc apply -f examples/minio.yaml
 	oc apply -f examples/minio-bucket-secret.yaml -n boot

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ oc apply -f $My-Frontend-CRD.yaml -n $NS
 
 For detailed configuration options and examples, see the [FrontendEnvironment Configuration Guide](docs/antora/modules/ROOT/pages/frontendenvironment-guide.adoc).
 
+If you are running a full app stack locally — including backend services managed by [Clowder](https://github.com/RedHatInsights/clowder) — you will need both operators running in your local cluster. See the Clowder repo for setup instructions.
+
 ## Local Development for Contributors
 
 **Note**: We only recommend this method for local development on the **operator** **itself**.
@@ -60,25 +62,17 @@ Please use the above section to develop an app that depends on this operator.
 
 You need to run kubernetes locally, we recommend [minikube](https://minikube.sigs.k8s.io/docs/).
 
-The frontend operator is dependent on [Clowder](https://github.com/RedHatInsights/clowder#getting-clowder). 
-Follow those directions to get Clowder running and continue along.  
+You will also need the [OpenShift CLI (`oc`)](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html) installed, as the resource commands use `oc` rather than `kubectl`.
 
-Once Clowder is up and running (`oc get pod -n clowder-system` has a running `controller-manager`), there are two
-options we can use to proceed. 
+```
+# Create the `boot` namespace (also regenerates manifests):
+make create-boot-namespace
 
-1. Create the boot namespace
-```
-$ make create-boot-namespace
-```
+# Install CRDs and example resources:
+make install-resources
 
-2. Install the resources:
-```
-$ make install-resources
-```
-
-3. Run:
-```
-$ make run-local
+# Run
+make run-local
 ```
 
 If you make changes to the CRDs make sure to install the resources and run again.
@@ -152,7 +146,7 @@ This will create a deployment and service for the reverse proxy, making it acces
 
 [Kuttl](https://kuttl.dev/) is an end to end testing framework for Kubernetes operators. We hope to provide full test coverage for the Frontend Operator with kuttl.
 
-To run the kuttl tests you'll need to be running the operator and Clowder in minikube as shown in the directions above. You also need to make sure you [have kuttl installed on your machine](https://kuttl.dev/docs/cli.html#setup-the-kuttl-kubectl-plugin).
+To run the kuttl tests you'll need to be running the operator in minikube as shown in the directions above. You also need to make sure you [have kuttl installed on your machine](https://kuttl.dev/docs/cli.html#setup-the-kuttl-kubectl-plugin).
 
 Once all that is in place you can run the kuttl tests:
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Once you update it you can access the app from `https://env-boot/insights/invent
 
 ### Pushcache (valpop) job
 
-The pushcache job or [valpop](https://github.com/RedHatInsights/valpop) copies frontend assets to an S3 bucket (MinIO locally). It is disabled by default in `examples/feenvironment.yaml` (`enablePushCache: false`), which is the correct setting for local development.
+The pushcache job or [valpop](https://github.com/RedHatInsights/valpop) copies frontend assets to an S3 bucket (MinIO locally). It is disabled by default in `examples/feenvironment.yaml` (`enablePushCache: false`).
 
 If you enable push cache (`enablePushCache: true`), you must also set `valpopImage` in the FrontendEnvironment, otherwise the operator will error on reconciliation:
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ If you enable push cache (`enablePushCache: true`), you must also set `valpopIma
 ```yaml
 spec:
   enablePushCache: true
-  valpopImage: quay.io/redhatinsights/valpop:latest
+  valpopImage: quay.io/redhat-services-prod/hcc-platex-services-tenant/valpop:latest
 ```
 
 For local development, MinIO is used as the S3 backend. The bucket secrets are stored under `examples/minio-bucket-secret.yaml`.

--- a/README.md
+++ b/README.md
@@ -29,20 +29,18 @@ See the [Local Development](#local-development-for-contributors) section below f
 
 ### Using the Frontend Operator
 
-The operator is generally available in the Consoledot Ephemeral and Dev Clusters. To use the Frontend Operator, you only need to apply a Frontend custom resource to a namespace that you manage using Bonfire.
+The Frontend Operator is already running in the Consoledot Ephemeral and Dev Clusters — you do not need to deploy it yourself. To use it, you simply apply a Frontend custom resource to a namespace you manage.
 
-### Deploying a Frontend with Bonfire in Ephemeral
+### Deploying a Frontend in Ephemeral
 
-[Bonfire](https://github.com/RedHatInsights/bonfire#bonfire-) is the consoledot tool used to interact with Kubernetes clusters.
+[Bonfire](https://github.com/RedHatInsights/bonfire#bonfire-) is the consoledot tool for deploying **applications** into ephemeral namespaces. It is not used to deploy the Frontend Operator itself.
 
-Simply login to the ephemeral cluster and run:
+To deploy your app into an ephemeral namespace where the operator is already running:
 ```bash
 bonfire deploy $MYAPP --frontends true -d 8h
 ```
 
-This will give you access to your own ephemeral environment.
-
-If your app does not have an entry into app-interface yet, `bonfire namespace reserve` will supply you with a bootstrapped namespace to deploy your application:
+If your app does not have an entry in app-interface yet, reserve a namespace and apply your Frontend resource manually:
 ```bash
 bonfire namespace reserve
 oc apply -f $My-Frontend-CRD.yaml -n $NS

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ This will create a deployment and service for the reverse proxy, making it acces
 
 [Kuttl](https://kuttl.dev/) is an end to end testing framework for Kubernetes operators. We hope to provide full test coverage for the Frontend Operator with kuttl.
 
-To run the kuttl tests you'll need to be running the operator in minikube as shown in the directions above. You also need to make sure you [have kuttl installed on your machine](https://kuttl.dev/docs/cli.html#setup-the-kuttl-kubectl-plugin).
+To run the kuttl tests you'll need to be running the operator in minikube as shown in the directions above. You also need to make sure you [have kuttl installed on your machine](https://github.com/kudobuilder/kuttl/blob/main/docs/cli.md).
 
 Once all that is in place you can run the kuttl tests:
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Once you update it you can access the app from `https://env-boot/insights/invent
 
 ### Pushcache (valpop) job
 
-The pushcache job or [valpop](https://github.com/RedHatInsights/valpop) copies frontend assets to an S3 bucket (MinIO locally). It is disabled by default in `examples/feenvironment.yaml` (`enablePushCache: false`).
+The pushcache job or [valpop](https://github.com/RedHatInsights/valpop) copies frontend assets to an S3 bucket (MinIO locally). It is enabled by default in `examples/feenvironment.yaml` using the valpop image from the Red Hat image registry.
 
 If you enable push cache (`enablePushCache: true`), you must also set `valpopImage` in the FrontendEnvironment, otherwise the operator will error on reconciliation:
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ You need to run kubernetes locally, we recommend [minikube](https://minikube.sig
 
 You will also need the [OpenShift CLI (`oc`)](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html) installed, as the resource commands use `oc` rather than `kubectl`.
 
+The operator creates Ingress resources (defaulting to the `nginx` ingress class) for each Frontend and for the reverse proxy. Enable the ingress addon if you want deployed frontends to be accessible in the browser:
+
+```sh
+minikube addons enable ingress
+```
+
 ```
 # Create the `boot` and `env-boot` namespaces (also regenerates manifests):
 make create-namespaces

--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ oc apply -f $My-Frontend-CRD.yaml -n $NS
 
 For detailed configuration options and examples, see the [FrontendEnvironment Configuration Guide](docs/antora/modules/ROOT/pages/frontendenvironment-guide.adoc).
 
-If you are running a full app stack locally — including backend services managed by [Clowder](https://github.com/RedHatInsights/clowder) — you will need both operators running in your local cluster. See the Clowder repo for setup instructions.
+If you are running a full app stack locally — including backend services managed by [Clowder](https://github.com/RedHatInsights/clowder) — you will need both operators running in your local cluster. See the Clowder repo for setup instructions. Once Clowder's CRDs are installed, apply the example ClowdEnvironment:
+
+```sh
+oc apply -f examples/clowdenvironment.yaml
+```
 
 ## Local Development for Contributors
 
@@ -65,15 +69,17 @@ You need to run kubernetes locally, we recommend [minikube](https://minikube.sig
 You will also need the [OpenShift CLI (`oc`)](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html) installed, as the resource commands use `oc` rather than `kubectl`.
 
 ```
-# Create the `boot` namespace (also regenerates manifests):
-make create-boot-namespace
+# Create the `boot` and `env-boot` namespaces (also regenerates manifests):
+make create-namespaces
 
 # Install CRDs and example resources:
 make install-resources
 
-# Run
+# Run (defaults to Info log level, use --log-level -1 for Debug)
 make run-local
 ```
+
+The operator supports the following log levels via `--log-level`: `-1` (Debug), `0` (Info), `1` (Warn), `2` (Error). `make run-local` defaults to Info.
 
 If you make changes to the CRDs make sure to install the resources and run again.
 
@@ -114,11 +120,17 @@ Once you update it you can access the app from `https://env-boot/insights/invent
 
 ### Pushcache (valpop) job
 
-The pushcache job or [valpop](https://github.com/RedHatInsights/valpop) will be disabled by default for all frontends.
+The pushcache job or [valpop](https://github.com/RedHatInsights/valpop) copies frontend assets to an S3 bucket (MinIO locally). It is disabled by default in `examples/feenvironment.yaml` (`enablePushCache: false`), which is the correct setting for local development.
 
-To disable the pushcache job altogether through the Frontend Operator, set `enablePushCache` to `false` in the frontend enviornment of the FEO.
+If you enable push cache (`enablePushCache: true`), you must also set `valpopImage` in the FrontendEnvironment, otherwise the operator will error on reconciliation:
 
-For local development purposes, the minio or AWS bucket secrets are stored under `examples/minio-bucket-secret.yaml`.
+```yaml
+spec:
+  enablePushCache: true
+  valpopImage: quay.io/redhatinsights/valpop:latest
+```
+
+For local development, MinIO is used as the S3 backend. The bucket secrets are stored under `examples/minio-bucket-secret.yaml`.
 
 ### Reverse Proxy
 

--- a/examples/feenvironment.yaml
+++ b/examples/feenvironment.yaml
@@ -11,7 +11,8 @@ spec:
     "us.console.dev.redhat.com": "https://sso.redhat.com/auth"
     "console.stage.openshiftusgov.com": "https://sso.stage.openshiftusgov.com"
     "console.openshiftusgov.com": "https://sso.openshiftusgov.com"
-  enablePushCache: false
+  enablePushCache: true
+  valpopImage: quay.io/redhat-services-prod/hcc-platex-services-tenant/valpop:latest
   reverseProxyImage: quay.io/redhat-services-prod/hcc-platex-services-tenant/frontend-asset-proxy:latest
   reverseProxyHostname: reverse-proxy.cluster.local
   reverseProxySPAEntrypointPath: /index.html

--- a/examples/feenvironment.yaml
+++ b/examples/feenvironment.yaml
@@ -11,7 +11,7 @@ spec:
     "us.console.dev.redhat.com": "https://sso.redhat.com/auth"
     "console.stage.openshiftusgov.com": "https://sso.stage.openshiftusgov.com"
     "console.openshiftusgov.com": "https://sso.openshiftusgov.com"
-  enablePushCache: true
+  enablePushCache: false
   reverseProxyImage: quay.io/redhat-services-prod/hcc-platex-services-tenant/frontend-asset-proxy:latest
   reverseProxyHostname: reverse-proxy.cluster.local
   reverseProxySPAEntrypointPath: /index.html


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHCLOUD-46458

CLAUDE.md was chosen over a custom Claude Code agent because the setup is a linear sequence of commands with known failure modes — not a decision-heavy, autonomous task.  

CLAUDE.md is automatically loaded when any developer opens Claude Code in this repo, requires no external tooling, and stays versioned alongside the code it documents.

- Remove Clowder as a prerequisite for operator contributor setup (not required at runtime; only a Go module dependency)                                                   
- Add Clowder callout in the app developer section for full-stack local deployments                                                                                        
- Correct namespace confusion: `boot` and `env-boot` are both namespaces; `env-boot` is also the `FrontendEnvironment` resource name                                                                
- Add `oc` as an explicit prerequisite (`make install-resources` uses `oc`, not `kubectl`)                                                                                 
- Remove redundant `make install` step; `make install-resources` applies CRDs directly                                                                                     
- Add CLAUDE.md with ordered setup steps, minikube/podman gotchas, and context safety guidance
- Rename create-boot-namespace → create-namespaces, add env-boot namespace (both boot and env-boot are required; alias kept for backwards compat)                                                                                                   
- Comment out clowdenvironment.yaml from install-resources (Clowder not required to run the operator; moved instruction to app developer section)                                                                                                
- Add `valpopImage` to `examples/feenvironment.yaml` so that `enablePushCache: true` (already enabled) doesn't break reconciliation in a fresh local env                                                                                                  
- Default run-local to Info log level (--log-level 0) instead of Error only                                                                                                
- Update README and CLAUDE.md to reflect all of the above