### PR TITLE
docs(antora): add widget layout template guide

### DIFF
--- a/docs/antora/modules/ROOT/nav.adoc
+++ b/docs/antora/modules/ROOT/nav.adoc
@@ -1,2 +1,3 @@
 * xref:frontendenvironment-guide.adoc[FrontendEnvironment Configuration Guide]
+* xref:widget-layout-guide.adoc[Widget Layout Template Guide]
 * xref:api_reference.adoc[API Reference]

--- a/docs/antora/modules/ROOT/pages/index.adoc
+++ b/docs/antora/modules/ROOT/pages/index.adoc
@@ -5,6 +5,7 @@ Welcome to the Frontend Operator documentation. The Frontend Operator is a Kuber
 == Getting Started
 
 * xref:frontendenvironment-guide.adoc[FrontendEnvironment Configuration Guide] - Learn how to create and configure FrontendEnvironment custom resources
+* xref:widget-layout-guide.adoc[Widget Layout Template Guide] - Learn how to define default dashboard layout templates for your widgets
 
 == Reference Documentation
 

--- a/docs/antora/modules/ROOT/pages/widget-layout-guide.adoc
+++ b/docs/antora/modules/ROOT/pages/widget-layout-guide.adoc
@@ -1,0 +1,449 @@
+= Widget Layout Template Guide
+:toc: left
+:toclevels: 3
+
+== Overview
+
+Applications that register dashboard widgets can also provide **default dashboard layout templates** — pre-arranged grids of widgets that users can fork and customize for their own dashboards. This is configured via `baseWidgetLayouts` in your application's `frontend.yml`.
+
+Layout templates define how widgets are positioned and sized across different screen sizes. The dashboard uses a responsive grid system with four breakpoints (`sm`, `md`, `lg`, `xl`), and each breakpoint specifies the position and dimensions of every widget in the layout.
+
+=== Prerequisites
+
+Your `frontend.yml` must have `feoConfigEnabled: true` set in the spec for the operator to process layout configuration:
+
+[source,yaml]
+----
+spec:
+  feoConfigEnabled: true
+----
+
+Without this flag, the operator ignores the `baseWidgetLayouts` section entirely.
+
+You must also have widgets registered via `widgetRegistry` (see xref:widget-registry-guide.adoc[Widget Registry Configuration Guide]) before you can reference them in layouts.
+
+== Quick Start
+
+Add a `baseWidgetLayouts` entry to your `frontend.yml` to define a layout template:
+
+[source,yaml]
+----
+baseWidgetLayouts:
+  - name: "default"
+    displayName: "Default Layout"
+    templateConfig:
+      sm:
+        - i: 'myApp#myWidget'
+          cx: 0
+          cy: 0
+          w: 1
+          h: 4
+      md:
+        - i: 'myApp#myWidget'
+          cx: 0
+          cy: 0
+          w: 1
+          h: 4
+      lg:
+        - i: 'myApp#myWidget'
+          cx: 0
+          cy: 0
+          w: 1
+          h: 4
+      xl:
+        - i: 'myApp#myWidget'
+          cx: 0
+          cy: 0
+          w: 1
+          h: 4
+----
+
+This registers a single layout template named "default" with one widget placed at the top-left corner across all breakpoints.
+
+== Template Name Prefixing
+
+Template names are automatically prefixed with the frontend name to ensure uniqueness across applications. The operator concatenates the frontend resource name with the template name using a hyphen.
+
+For example, if your frontend resource is named `widgets` and your template name is `landing`:
+
+* The template name in `frontend.yml`: `landing`
+* The resulting name after processing: `widgets-landing`
+
+This prevents name collisions when multiple applications provide layout templates.
+
+== Field Reference
+
+=== `BaseWidgetDashboardTemplate`
+
+Each entry in the `baseWidgetLayouts` array defines one layout template:
+
+[cols="1,1,1,3"]
+|===
+|Field |Type |Required |Description
+
+|`name`
+|string
+|Yes
+|Template name. Automatically prefixed with the frontend name for uniqueness (e.g., template `landing` in frontend `widgets` becomes `widgets-landing`).
+
+|`displayName`
+|string
+|Yes
+|Human-readable name shown to users in the template picker.
+
+|`templateConfig`
+|object
+|Yes
+|Responsive breakpoint definitions. Contains `sm`, `md`, `lg`, and `xl` keys.
+|===
+
+=== `templateConfig` — Responsive Breakpoints
+
+The `templateConfig` object defines widget positions and sizes for each screen size:
+
+[cols="1,3"]
+|===
+|Breakpoint |Description
+
+|`sm`
+|Small screens — single-column layout. All widgets stack vertically.
+
+|`md`
+|Medium screens — 2-column grid.
+
+|`lg`
+|Large screens — 3-column grid.
+
+|`xl`
+|Extra-large screens — 4-column grid.
+|===
+
+Each breakpoint contains an array of grid items describing widget placement.
+
+**All four breakpoints are required.** Each breakpoint should include the same set of widgets, repositioned and resized for the screen width.
+
+=== Grid Item Fields
+
+Each item in a breakpoint array describes a single widget's position and size in the grid:
+
+[cols="1,1,1,3"]
+|===
+|Field |Type |Required |Description
+
+|`i`
+|string
+|Yes
+|Unique widget identifier. Format: `scope#module` — references a widget from the widget registry. For example, `rhel#rhel` references the widget with scope `rhel` and module identifier `rhel`.
+
+|`w`
+|integer
+|Yes
+|Width of the widget in grid columns. Must fit within the breakpoint's column count.
+
+|`h`
+|integer
+|Yes
+|Height of the widget in grid rows.
+
+|`cx`
+|integer
+|Yes
+|Column position (x-coordinate). Zero-based. Uses `cx` instead of `x` because some YAML parsers treat bare `y` as a boolean (`true`).
+
+|`cy`
+|integer
+|Yes
+|Row position (y-coordinate). Zero-based. Uses `cy` instead of `y` for the same YAML parser compatibility reason as `cx`.
+
+|`maxH`
+|integer
+|No
+|Maximum height the user can resize the widget to. Prevents excessively tall widgets.
+
+|`minH`
+|integer
+|No
+|Minimum height the user can resize the widget to. Prevents widgets from being collapsed too small.
+
+|`static`
+|boolean
+|No
+|When `true`, the widget is locked in place — users cannot move or resize it. Useful for hero widgets or important announcements that should stay fixed.
+|===
+
+NOTE: The `cx`/`cy` naming convention exists because `x` and `y` are reserved keywords in some YAML parsers (notably, `y` is interpreted as boolean `true`). Always use `cx` and `cy` in your layout definitions.
+
+== Examples
+
+=== Minimal Layout — Single Breakpoint Pattern
+
+A simple template with two widgets:
+
+[source,yaml]
+----
+baseWidgetLayouts:
+  - name: "simple"
+    displayName: "Simple Overview"
+    templateConfig:
+      sm:
+        - i: 'myApp#statusWidget'
+          cx: 0
+          cy: 0
+          w: 1
+          h: 4
+        - i: 'myApp#activityWidget'
+          cx: 0
+          cy: 1
+          w: 1
+          h: 5
+      md:
+        - i: 'myApp#statusWidget'
+          cx: 0
+          cy: 0
+          w: 1
+          h: 4
+        - i: 'myApp#activityWidget'
+          cx: 1
+          cy: 0
+          w: 1
+          h: 5
+      lg:
+        - i: 'myApp#statusWidget'
+          cx: 0
+          cy: 0
+          w: 1
+          h: 4
+        - i: 'myApp#activityWidget'
+          cx: 1
+          cy: 0
+          w: 2
+          h: 5
+      xl:
+        - i: 'myApp#statusWidget'
+          cx: 0
+          cy: 0
+          w: 1
+          h: 4
+        - i: 'myApp#activityWidget'
+          cx: 1
+          cy: 0
+          w: 3
+          h: 5
+----
+
+Notice how the activity widget gets wider on larger screens while the status widget stays the same size.
+
+=== Full Responsive Layout
+
+A complete layout with multiple widgets demonstrating progressive enhancement across breakpoints:
+
+[source,yaml]
+----
+baseWidgetLayouts:
+  - name: "dashboard"
+    displayName: "Full Dashboard"
+    templateConfig:
+      sm:
+        # Single column — all widgets stack vertically
+        - i: 'myApp#overview'
+          cx: 0
+          cy: 0
+          w: 1
+          h: 4
+          maxH: 10
+          minH: 1
+        - i: 'myApp#activity'
+          cx: 0
+          cy: 1
+          w: 1
+          h: 5
+          maxH: 10
+          minH: 1
+        - i: 'myApp#alerts'
+          cx: 0
+          cy: 2
+          w: 1
+          h: 4
+          maxH: 10
+          minH: 1
+      md:
+        # Two columns
+        - i: 'myApp#overview'
+          cx: 0
+          cy: 0
+          w: 1
+          h: 4
+          maxH: 10
+          minH: 1
+        - i: 'myApp#activity'
+          cx: 1
+          cy: 0
+          w: 1
+          h: 5
+          maxH: 10
+          minH: 1
+        - i: 'myApp#alerts'
+          cx: 0
+          cy: 1
+          w: 2
+          h: 4
+          maxH: 10
+          minH: 1
+      lg:
+        # Three columns
+        - i: 'myApp#overview'
+          cx: 0
+          cy: 0
+          w: 1
+          h: 4
+          maxH: 10
+          minH: 1
+        - i: 'myApp#activity'
+          cx: 1
+          cy: 0
+          w: 1
+          h: 5
+          maxH: 10
+          minH: 1
+        - i: 'myApp#alerts'
+          cx: 2
+          cy: 0
+          w: 1
+          h: 4
+          maxH: 10
+          minH: 1
+      xl:
+        # Four columns — overview spans two
+        - i: 'myApp#overview'
+          cx: 0
+          cy: 0
+          w: 2
+          h: 4
+          maxH: 10
+          minH: 1
+        - i: 'myApp#activity'
+          cx: 2
+          cy: 0
+          w: 1
+          h: 5
+          maxH: 10
+          minH: 1
+        - i: 'myApp#alerts'
+          cx: 3
+          cy: 0
+          w: 1
+          h: 4
+          maxH: 10
+          minH: 1
+----
+
+=== Layout with Static Widgets
+
+A layout where the hero widget is locked in place:
+
+[source,yaml]
+----
+baseWidgetLayouts:
+  - name: "featured"
+    displayName: "Featured Layout"
+    templateConfig:
+      sm:
+        - i: 'myApp#hero'
+          cx: 0
+          cy: 0
+          w: 1
+          h: 6
+          static: true
+        - i: 'myApp#details'
+          cx: 0
+          cy: 1
+          w: 1
+          h: 4
+      md:
+        - i: 'myApp#hero'
+          cx: 0
+          cy: 0
+          w: 2
+          h: 6
+          static: true
+        - i: 'myApp#details'
+          cx: 0
+          cy: 1
+          w: 2
+          h: 4
+      lg:
+        - i: 'myApp#hero'
+          cx: 0
+          cy: 0
+          w: 3
+          h: 6
+          static: true
+        - i: 'myApp#details'
+          cx: 0
+          cy: 1
+          w: 3
+          h: 4
+      xl:
+        - i: 'myApp#hero'
+          cx: 0
+          cy: 0
+          w: 4
+          h: 6
+          static: true
+        - i: 'myApp#details'
+          cx: 0
+          cy: 1
+          w: 4
+          h: 4
+----
+
+The hero widget uses `static: true` so users cannot move or resize it, ensuring it always occupies the full-width top position.
+
+== Responsive Grid Model
+
+The dashboard grid adapts to screen width using four breakpoints. Each breakpoint determines how many columns the grid has:
+
+[cols="1,1,3"]
+|===
+|Breakpoint |Columns |Typical Usage
+
+|`sm`
+|1
+|Mobile and narrow windows — all widgets stack in a single column.
+
+|`md`
+|2
+|Tablets and smaller desktops — widgets can sit side by side.
+
+|`lg`
+|3
+|Standard desktops — three-column layout for balanced content distribution.
+
+|`xl`
+|4
+|Wide monitors — four columns for maximum information density.
+|===
+
+When designing layouts, consider:
+
+* **Small screens** — stack widgets vertically. Set `w: 1` for all items and increment `cy` for each widget.
+* **Medium screens** — start placing widgets side by side. Use `cx: 0` and `cx: 1` to distribute across two columns.
+* **Large screens** — take advantage of three columns. Consider making important widgets wider (`w: 2`) to span multiple columns.
+* **Extra-large screens** — use the full four columns. Hero widgets can span 3-4 columns for visual impact.
+
+== Real-World Reference
+
+The https://github.com/RedHatInsights/landing-page-frontend/blob/master/frontend.yml[landing-page-frontend/frontend.yml] is the canonical real-world example of both widget registration and layout templates in production. It defines:
+
+* A `landingPage` template with 10 widgets (RHEL, OpenShift, Ansible, Recently Visited, Favorite Services, Subscriptions, Explore Capabilities, OpenShift AI, Image Builder, ACS)
+* Full responsive layouts across all four breakpoints
+* Progressive layout changes: single-column stacking on `sm`, two-column on `md`, three-column on `lg`, four-column on `xl`
+* Widgets that change size across breakpoints (e.g., Explore Capabilities spans more columns on larger screens)
+
+Review this file for a production-scale example of responsive layout design.
+
+== Next Steps
+
+* xref:widget-registry-guide.adoc[Widget Registry Configuration Guide] — register widgets before referencing them in layouts
+* xref:frontendenvironment-guide.adoc[FrontendEnvironment Configuration Guide] — environment-level configuration
+* xref:api_reference.adoc[API Reference] — complete API specification


### PR DESCRIPTION
## Summary

Adds an Antora documentation page for the `baseWidgetLayouts` section of `frontend.yml`, enabling app teams to define default dashboard layout templates without reading operator source code.

### What's documented

- `BaseWidgetDashboardTemplate` structure (`name`, `displayName`, `templateConfig`)
- Responsive breakpoints (`sm`, `md`, `lg`, `xl`) and column model
- All grid item fields (`w`, `h`, `cx`, `cy`, `i`, `static`, `maxH`, `minH`)
- Template name prefixing (frontend name + template name for uniqueness)
- `cx`/`cy` naming convention (YAML reserved keyword avoidance)
- Three examples: minimal layout, full responsive layout, static (locked) widgets
- Reference to `landing-page-frontend/frontend.yml` as canonical production example

### Changes

- `docs/antora/modules/ROOT/pages/widget-layout-guide.adoc` — new guide (449 lines)
- `docs/antora/modules/ROOT/nav.adoc` — added nav entry
- `docs/antora/modules/ROOT/pages/index.adoc` — added Getting Started link

RHCLOUD-47478