### PR TITLE
fix(dependencies): update renovate and use proper version of go toolchain

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-go@v5
         name: Set up Go 1.x
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
 
       - uses: actions/checkout@v4
         name: Checkout frontend-operator

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-go@v5
         name: Set up golang 1.25
         with:
-          go-version: '1.25.9'
+          go-version: '1.25.10'
       - name: Check out source code
         uses: actions/checkout@v4
       - name: Install package and dependencies

--- a/.tekton/frontend-operator-pull-request.yaml
+++ b/.tekton/frontend-operator-pull-request.yaml
@@ -36,8 +36,7 @@ spec:
   - name: prefetch-input
     value: gomod
   - name: build-args
-    value:
-    - GOTOOLCHAIN_MODE=local
+    value: []
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -270,14 +269,14 @@ spec:
           computeResources: {}
           image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
           name: use-trusted-artifact
-        - image: registry.access.redhat.com/ubi9/go-toolset:latest
+        - image: registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778504036@sha256:2c17ce45c735ad308240139d807eeb22f4499fd90e883634ba5a191779f1ff94
           name: checks
           workingDir: /var/workdir/source
           securityContext:
             runAsUser: 0
           env:
           - name: GOTOOLCHAIN
-            value: local
+            value: auto
           - name: GOPATH
             value: /tmp/go
           computeResources:

--- a/.tekton/frontend-operator-push.yaml
+++ b/.tekton/frontend-operator-push.yaml
@@ -33,8 +33,7 @@ spec:
   - name: prefetch-input
     value: gomod
   - name: build-args
-    value:
-    - GOTOOLCHAIN_MODE=local
+    value: []
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -267,14 +266,14 @@ spec:
           computeResources: {}
           image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
           name: use-trusted-artifact
-        - image: registry.access.redhat.com/ubi9/go-toolset:latest
+        - image: registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778504036@sha256:2c17ce45c735ad308240139d807eeb22f4499fd90e883634ba5a191779f1ff94
           name: checks
           workingDir: /var/workdir/source
           securityContext:
             runAsUser: 0
           env:
           - name: GOTOOLCHAIN
-            value: local
+            value: auto
           - name: GOPATH
             value: /tmp/go
           computeResources:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,7 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:latest as base
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778504036@sha256:2c17ce45c735ad308240139d807eeb22f4499fd90e883634ba5a191779f1ff94 AS base
 
-# Default to 'auto' so Go downloads the exact toolchain version specified in
-# go.mod (e.g. go1.25.10).  This ensures the built binary uses the patched
-# stdlib and passes Grype vulnerability scans in GHA.
-#
-# For hermetic/cachi2 builds (Konflux), override with:
-#   --build-arg GOTOOLCHAIN_MODE=local
-# to avoid network downloads during the restricted build phase.
-ARG GOTOOLCHAIN_MODE=auto
-ENV GOTOOLCHAIN=${GOTOOLCHAIN_MODE}
+ENV GOTOOLCHAIN=auto
 
 WORKDIR /workspace
 
@@ -31,7 +23,7 @@ RUN rm -rf api
 RUN rm -rf controllers
 
 # Build the manager binary
-FROM base as builder
+FROM base AS builder
 
 WORKDIR /workspace
 
@@ -51,7 +43,7 @@ COPY controllers/ controllers/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux go build -o manager main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9-minimal:9.7-1778461551@sha256:fe9e574f04371b333ed4e21d30d984f6b7fcd1046e579f5ddab4816c0c8e231d
 WORKDIR /
 COPY licenses/ licenses/
 COPY --from=builder /workspace/manager .

--- a/build/Dockerfile.pr
+++ b/build/Dockerfile.pr
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:latest
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778504036@sha256:2c17ce45c735ad308240139d807eeb22f4499fd90e883634ba5a191779f1ff94
 
 USER 0
 RUN dnf install -y openssh-clients git podman make which go jq python3

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/RedHatInsights/frontend-operator
 
-go 1.25.0
-
-toolchain go1.25.10
+go 1.25.9
 
 require (
 	github.com/RedHatInsights/clowder v0.100.0

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,12 @@
   "baseBranches": ["main"],
   "tekton": {
     "schedule": ["at any time"]
-  }
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "all minor and patch dependencies",
+      "groupSlug": "all-minor-patch"
+    }
+  ]
 }


### PR DESCRIPTION
### Description
<!-- Summary of proposed changes: what and why. -->

Let's update renovate to open single PR for minor and patch dependencies. Also update how build proceeds so newer version of go toolchain is used.

---

### Anything reviewers should know?

We are not using hermetic builds in here so we can use the newer version of go toolchain. Once we fully enable hermetic builds in Konflux we'll have to obey what version Konflux provides.

---

### Checklist
- [x] Tests: new/updated tests cover the change
- [x] API: spec updated if endpoints changed (or N/A)
- [x] Migrations: backwards compatible if schema changed (or N/A)
- [x] Dependencies: no known impact to dependent services
- [x] Security: reviewed against [secure coding checklist](https://github.com/RedHatInsights/secure-coding-checklist) (or N/A)

### AI disclosure
Assisted by: Claude Code
