### PR TITLE
fix(cachebust): Fix akamai-edgerc not updating on update

### DIFF
--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -394,9 +394,17 @@ func (r *FrontendReconciliation) populateCacheBustContainer(j *batchv1.Job) erro
 		"edgerc": edgercFile,
 	}
 
-	// Create the configmap with the Client if it doesn't already exist
+	// Create the configmap with the Client if it doesn't already exist or update the existing one
 	if err := r.Client.Create(r.Ctx, configMap); err != nil {
 		if !k8serr.IsAlreadyExists(err) {
+			return err
+		}
+		existing := &v1.ConfigMap{}
+		if err := r.Client.Get(r.Ctx, nn, existing); err != nil {
+			return err
+		}
+		existing.Data = configMap.Data
+		if err := r.Client.Update(r.Ctx, existing); err != nil {
 			return err
 		}
 	}

--- a/tests/e2e/cachebust/03-update-resources.yaml
+++ b/tests/e2e/cachebust/03-update-resources.yaml
@@ -1,4 +1,16 @@
 ---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: akamai
+  namespace: test-cachebust
+data:
+  access_token: "bmV3X2FjY2Vzc190b2tlbg=="
+  client_secret: "bmV3X2NsaWVudF9zZWNyZXQ="
+  client_token: "bmV3X2NsaWVudF90b2tlbg=="
+  host: "bmV3X2hvc3Q="
+type: Opaque
+---
 apiVersion: cloud.redhat.com/v1alpha1
 kind: FrontendEnvironment
 metadata:

--- a/tests/e2e/cachebust/04-assert.yaml
+++ b/tests/e2e/cachebust/04-assert.yaml
@@ -268,3 +268,21 @@ spec:
             - name: config-chrome
               mountPath: /srv/dist/operator-generated/fed-modules.json
               subPath: fed-modules.json
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: akamai-edgerc
+  namespace: test-cachebust
+data:
+  edgerc: |
+    [default]
+    host = new_host
+    access_token = new_access_token
+    client_token = new_client_token
+    client_secret = new_client_secret
+    [ccu]
+    host = new_host
+    access_token = new_access_token
+    client_token = new_client_token
+    client_secret = new_client_secret


### PR DESCRIPTION
### Description
<!-- Summary of proposed changes: what and why. -->

The frontend operator was not updating the akamai-edgerc ConfigMap when the
akamai secret was updated in app-interface. This meant cache bust jobs
were having the incorrect credentials on update, requiring manual
deletion of the edgerc ConfigMap in OpenShift and a redeploy of the operator.

The fix changes the populateCacheBustContainer function in reconcile.go to update
the existing ConfigMap data when it already exists, instead of silently skipping
creation.

[RHCLOUD-48181](https://redhat.atlassian.net/browse/RHCLOUD-48181)


---

### How to test locally
<!-- How can a reviewer exercise this? Special setup, env vars, seed data? -->
<!-- Bug fixes: how to reproduce the original bug and confirm the fix. -->
To reproduce the bug comment out lines #`402-409` (kuttl tests will hang)

Run the KUTTL tests using:
make kuttl

---

### Anything reviewers should know?
<!-- Trade-offs, performance considerations, pre/post merge actions required. -->
Instead of checking for a difference between the config map decided to simply update it on every reconcile instead of adding unnecessary/complex diff checks
---

### Checklist
- [ ] Tests: new/updated tests cover the change
- [ ] API: spec updated if endpoints changed (or N/A)
- [ ] Migrations: backwards compatible if schema changed (or N/A)
- [X] Dependencies: no known impact to dependent services
- [ ] Security: reviewed against [secure coding checklist](https://github.com/RedHatInsights/secure-coding-checklist) (or N/A)

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->
Assisted by: Claude Code


[RHCLOUD-48181]: https://redhat.atlassian.net/browse/RHCLOUD-48181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ