### PR TITLE
feat: read MinIO credentials from Clowder Secret on ephemeral

### DIFF
--- a/controllers/ephemeral_objectstore_test.go
+++ b/controllers/ephemeral_objectstore_test.go
@@ -1,0 +1,134 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestExtractBucketConfigFromSecret(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1.AddToScheme(scheme)
+
+	namespace := "ephemeral-abcdef"
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "env-" + namespace + "-minio",
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"accessKey": []byte("test-access"),
+			"secretKey": []byte("test-secret"),
+			"hostname":  []byte("env-ephemeral-abcdef-minio.ephemeral-abcdef.svc"),
+			"port":      []byte("9000"),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(secret).
+		Build()
+
+	result, err := extractBucketConfigFromSecret(context.Background(), fakeClient, namespace)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if *result.AccessKey != "test-access" {
+		t.Errorf("AccessKey = %q, want %q", *result.AccessKey, "test-access")
+	}
+	if *result.SecretKey != "test-secret" {
+		t.Errorf("SecretKey = %q, want %q", *result.SecretKey, "test-secret")
+	}
+	if *result.Endpoint != "env-ephemeral-abcdef-minio.ephemeral-abcdef.svc" {
+		t.Errorf("Endpoint = %q, want %q", *result.Endpoint, "env-ephemeral-abcdef-minio.ephemeral-abcdef.svc")
+	}
+	if *result.Port != "9000" {
+		t.Errorf("Port = %q, want %q", *result.Port, "9000")
+	}
+	if *result.Name != "frontend-pushcache" {
+		t.Errorf("Name = %q, want %q", *result.Name, "frontend-pushcache")
+	}
+	if *result.Region != "us-east-1" {
+		t.Errorf("Region = %q, want %q", *result.Region, "us-east-1")
+	}
+	if *result.TLS != false {
+		t.Errorf("TLS = %v, want false", *result.TLS)
+	}
+}
+
+func TestExtractBucketConfigFromSecretMissing(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	_, err := extractBucketConfigFromSecret(context.Background(), fakeClient, "ephemeral-xyz")
+	if err == nil {
+		t.Fatal("expected error when Secret is missing, got nil")
+	}
+}
+
+func TestExtractBucketConfigFromSecretMissingKeys(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1.AddToScheme(scheme)
+
+	namespace := "ephemeral-abc"
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "env-" + namespace + "-minio",
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"accessKey": []byte("key"),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(secret).
+		Build()
+
+	_, err := extractBucketConfigFromSecret(context.Background(), fakeClient, namespace)
+	if err == nil {
+		t.Fatal("expected error when Secret is missing required keys, got nil")
+	}
+}
+
+func TestExtractBucketConfigFromSecretDefaultPort(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1.AddToScheme(scheme)
+
+	namespace := "ephemeral-noport"
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "env-" + namespace + "-minio",
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"accessKey": []byte("key"),
+			"secretKey": []byte("secret"),
+			"hostname":  []byte("minio.svc"),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(secret).
+		Build()
+
+	result, err := extractBucketConfigFromSecret(context.Background(), fakeClient, namespace)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if *result.Port != "9000" {
+		t.Errorf("Port = %q, want default %q", *result.Port, "9000")
+	}
+}

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -521,7 +521,7 @@ func (r *FrontendReconciliation) populatePushCacheContainer(j *batchv1.Job) erro
 		return err
 	}
 
-	objectStoreInfo, err := ExtractBucketConfigFromEnv()
+	objectStoreInfo, err := getObjectStoreConfig(r.Ctx, r.Client, r.Frontend.Namespace)
 	if err != nil {
 		return err
 	}
@@ -734,6 +734,51 @@ func ExtractBucketConfigFromEnv() (*ObjectStoreBucket, error) {
 	}
 
 	return bucketConfig, nil
+}
+
+func extractBucketConfigFromSecret(ctx context.Context, c client.Client, namespace string) (*ObjectStoreBucket, error) {
+	// Clowder creates the MinIO Secret with name "<clowdenv>-minio" in the target namespace.
+	// The ClowdEnvironment name follows the convention "env-<namespace>".
+	clowdEnvName := "env-" + namespace
+	secretName := clowdEnvName + "-minio"
+	secret := &v1.Secret{}
+	if err := c.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret); err != nil {
+		return nil, fmt.Errorf("failed to get MinIO secret %q in namespace %q: %w", secretName, namespace, err)
+	}
+
+	accessKey := string(secret.Data["accessKey"])
+	secretKey := string(secret.Data["secretKey"])
+	hostname := string(secret.Data["hostname"])
+	port := string(secret.Data["port"])
+
+	if accessKey == "" || secretKey == "" || hostname == "" {
+		return nil, fmt.Errorf("MinIO secret %q is missing required keys (accessKey, secretKey, hostname)", secretName)
+	}
+
+	if port == "" {
+		port = "9000"
+	}
+
+	bucketName := "frontend-pushcache"
+	region := "us-east-1"
+
+	return &ObjectStoreBucket{
+		AccessKey: &accessKey,
+		SecretKey: &secretKey,
+		Name:      &bucketName,
+		Region:    &region,
+		Endpoint:  &hostname,
+		Port:      &port,
+		TLS:       utils.FalsePtr(),
+	}, nil
+}
+
+func getObjectStoreConfig(ctx context.Context, c client.Client, namespace string) (*ObjectStoreBucket, error) {
+	config, err := ExtractBucketConfigFromEnv()
+	if err == nil {
+		return config, nil
+	}
+	return extractBucketConfigFromSecret(ctx, c, namespace)
 }
 
 // Add the env vars if eny are set


### PR DESCRIPTION
### Description
In ephemeral environments, the Frontend Operator couldn't create valpop pushcache Jobs because it relied on PUSHCACHE_AWS_* env vars for MinIO credentials. Those env vars are set on stage/prod via app-interface/Vault, but on ephemeral each namespace has its own Clowder-provisioned MinIO with unique credentials stored in an env-<namespace>-minio Secret.

  This change adds a fallback: when PUSHCACHE_AWS_* env vars are not set, FEO reads MinIO credentials from the Clowder-created Secret (env-<namespace>-minio) in the Frontend's namespace. Stage/prod behavior is unchanged — env vars are always set there, so the fallback is never reached.

Related to [RHCLOUD-47016](https://redhat.atlassian.net/browse/RHCLOUD-47016)

---

### Anything reviewers should know?
  - The Secret name convention (env-<namespace>-minio) matches Clowder's GetNamespacedName(env, "minio") pattern where the ClowdEnvironment is named env-<namespace> (bonfire convention)
  - Hardcoded defaults for ephemeral: bucket frontend-pushcache, region us-east-1, TLS false — matching Clowder's createReverseProxyBucket() and makeLocalReverseProxy()
  - Only the pushcache path is changed; the reverse proxy container still uses ExtractBucketConfigFromEnv() as before

[RHCLOUD-47016]: https://redhat.atlassian.net/browse/RHCLOUD-47016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ